### PR TITLE
Switch to Google PubSub

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/model/entity/MessageToSend.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/model/entity/MessageToSend.java
@@ -1,0 +1,38 @@
+package uk.gov.ons.ssdc.responseoperations.model.entity;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import lombok.Data;
+import org.hibernate.annotations.Type;
+
+@Data
+@Entity
+public class MessageToSend {
+  @Id private UUID id;
+
+  @Column private String destinationTopic;
+
+  @Lob
+  @Type(type = "org.hibernate.type.BinaryType")
+  @Column
+  private byte[] messageBody;
+
+  public void setMessageBody(String messageBodyStr) {
+    if (messageBodyStr == null) {
+      messageBody = null;
+    } else {
+      messageBody = messageBodyStr.getBytes();
+    }
+  }
+
+  public String getMessageBody() {
+    if (messageBody == null) {
+      return null;
+    }
+
+    return new String(messageBody);
+  }
+}


### PR DESCRIPTION
# Motivation and Context
We wanted to get rid of RabbitMQ because it's not cloud native, and it's therefore a pain to support and maintain in the cloud, plus we needed to migrate away from classic queues anyway, so why not just switch to Google PubSub, given that we're hosted in GCP?

# What has changed
Replaced RabbitMQ with Google PubSub.

# How to test?
Build the Case Processor, Case API, Support Tool and Print File Service. Run docker dev `make up` and then run acceptance tests `make test`

# Links
Trello: https://trello.com/c/W86A71JQ