### PR TITLE
Configure print suppliers via JSON file

### DIFF
--- a/dummy-print-supplier-config.json
+++ b/dummy-print-supplier-config.json
@@ -1,0 +1,10 @@
+{
+  "SUPPLIER_A": {
+    "sftpDirectory": "foo",
+    "encryptionKeyFilename": "bar"
+  },
+  "SUPPLIER_B": {
+    "sftpDirectory": "foo",
+    "encryptionKeyFilename": "bar"
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/config/PrintSupplierConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/config/PrintSupplierConfig.java
@@ -1,0 +1,39 @@
+package uk.gov.ons.ssdc.responseoperations.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import utility.ObjectMapperFactory;
+
+@Configuration
+public class PrintSupplierConfig {
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.objectMapper();
+
+  private Set<String> printSuppliers = null;
+
+  @Value("${printsupplierconfigfile}")
+  private String configFile;
+
+  public Set<String> getPrintSuppliers() {
+    if (printSuppliers != null) {
+      return printSuppliers;
+    }
+
+    try (InputStream configFileStream = new FileInputStream(configFile)) {
+      Map map = OBJECT_MAPPER.readValue(configFileStream, Map.class);
+      printSuppliers = map.keySet();
+      return printSuppliers;
+    } catch (JsonProcessingException | FileNotFoundException e) {
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/PrintTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/PrintTemplateEndpoint.java
@@ -1,9 +1,6 @@
 package uk.gov.ons.ssdc.responseoperations.endpoint;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,27 +12,27 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.responseoperations.config.PrintSupplierConfig;
 import uk.gov.ons.ssdc.responseoperations.model.dto.ui.PrintTemplateDto;
 import uk.gov.ons.ssdc.responseoperations.model.entity.PrintTemplate;
 import uk.gov.ons.ssdc.responseoperations.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.responseoperations.model.repository.PrintTemplateRepository;
 import uk.gov.ons.ssdc.responseoperations.security.UserIdentity;
-import utility.ObjectMapperFactory;
 
 @RestController
 @RequestMapping(value = "/api/printtemplates")
 public class PrintTemplateEndpoint {
-  public static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.objectMapper();
   private final PrintTemplateRepository printTemplateRepository;
   private final UserIdentity userIdentity;
-
-  @Value("${printsupplierconfig}")
-  private String printSupplierConfig;
+  private final PrintSupplierConfig printSupplierConfig;
 
   public PrintTemplateEndpoint(
-      PrintTemplateRepository printTemplateRepository, UserIdentity userIdentity) {
+      PrintTemplateRepository printTemplateRepository,
+      UserIdentity userIdentity,
+      PrintSupplierConfig printSupplierConfig) {
     this.printTemplateRepository = printTemplateRepository;
     this.userIdentity = userIdentity;
+    this.printSupplierConfig = printSupplierConfig;
   }
 
   @GetMapping
@@ -98,15 +95,7 @@ public class PrintTemplateEndpoint {
   }
 
   private void checkPrintSupplierValid(String printSupplier) {
-    Map printSupplierMap = null;
-
-    try {
-      printSupplierMap = OBJECT_MAPPER.readValue(printSupplierConfig, Map.class);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-
-    if (!printSupplierMap.containsKey(printSupplier)) {
+    if (!printSupplierConfig.getPrintSuppliers().contains(printSupplier)) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Print supplier unknown: " + printSupplier);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,5 +67,5 @@ iapaudience: DUMMY
 # TODO: Remove this before releasing to prod
 dummyuseridentity: dummy@fake-email.com
 
-printsupplierconfig: '{"SUPPLIER_A":{"sftpDirectory":"foo","encryptionKeyFilename": "bar"},"SUPPLIER_B":{"sftpDirectory":"foo","encryptionKeyFilename":"bar"}}'
+printsupplierconfigfile: dummy-print-supplier-config.json
 

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/PrintTemplateEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/PrintTemplateEndpointTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.ons.ssdc.responseoperations.test_utils.JsonHelper.asJsonString;
 
 import java.util.List;
+import java.util.Set;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,9 +22,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.ons.ssdc.responseoperations.config.PrintSupplierConfig;
 import uk.gov.ons.ssdc.responseoperations.model.dto.ui.PrintTemplateDto;
 import uk.gov.ons.ssdc.responseoperations.model.entity.PrintTemplate;
 import uk.gov.ons.ssdc.responseoperations.model.entity.UserGroupAuthorisedActivityType;
@@ -36,6 +37,8 @@ class PrintTemplateEndpointTest {
   @Mock private PrintTemplateRepository printTemplateRepository;
 
   @Mock private UserIdentity userIdentity;
+
+  @Mock private PrintSupplierConfig printSupplierConfig;
 
   @InjectMocks private PrintTemplateEndpoint underTest;
 
@@ -76,10 +79,7 @@ class PrintTemplateEndpointTest {
   @Test
   public void testCreatePrintTemplate() throws Exception {
 
-    ReflectionTestUtils.setField(
-        underTest,
-        "printSupplierConfig",
-        "{\"SUPPLIER_A\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\": \"bar\"},\"SUPPLIER_B\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\":\"bar\"}}");
+    when(printSupplierConfig.getPrintSuppliers()).thenReturn(Set.of("SUPPLIER_A"));
 
     PrintTemplateDto printTemplateDto = new PrintTemplateDto();
     printTemplateDto.setPackCode("packCode1");
@@ -108,10 +108,6 @@ class PrintTemplateEndpointTest {
 
   @Test
   public void testThatEmptyPackCodeIsRejected() throws Exception {
-    ReflectionTestUtils.setField(
-        underTest,
-        "printSupplierConfig",
-        "{\"SUPPLIER_A\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\": \"bar\"},\"SUPPLIER_B\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\":\"bar\"}}");
 
     PrintTemplateDto printTemplateDto = new PrintTemplateDto();
     printTemplateDto.setPackCode("");
@@ -134,10 +130,6 @@ class PrintTemplateEndpointTest {
 
   @Test
   public void testThatNoneUniquePackCodeIsRejected() throws Exception {
-    ReflectionTestUtils.setField(
-        underTest,
-        "printSupplierConfig",
-        "{\"SUPPLIER_A\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\": \"bar\"},\"SUPPLIER_B\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\":\"bar\"}}");
 
     PrintTemplateDto printTemplateDto = new PrintTemplateDto();
     printTemplateDto.setPackCode("PackCodeA");
@@ -167,10 +159,7 @@ class PrintTemplateEndpointTest {
   @Test
   public void testCreatePrintTemplateFailsWithInvalidPrintSupplier() throws Exception {
 
-    ReflectionTestUtils.setField(
-        underTest,
-        "printSupplierConfig",
-        "{\"SUPPLIER_A\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\": \"bar\"},\"SUPPLIER_B\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\":\"bar\"}}");
+    when(printSupplierConfig.getPrintSuppliers()).thenReturn(Set.of("SUPPLIER_A"));
 
     PrintTemplateDto printTemplateDto = new PrintTemplateDto();
     printTemplateDto.setPackCode("packCode1");
@@ -193,10 +182,6 @@ class PrintTemplateEndpointTest {
 
   @Test
   public void testEmptyTemplateThrowsError() throws Exception {
-    ReflectionTestUtils.setField(
-        underTest,
-        "printSupplierConfig",
-        "{\"SUPPLIER_A\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\": \"bar\"},\"SUPPLIER_B\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\":\"bar\"}}");
 
     PrintTemplateDto printTemplateDto = new PrintTemplateDto();
     printTemplateDto.setPackCode("packCode1");
@@ -219,10 +204,6 @@ class PrintTemplateEndpointTest {
 
   @Test
   public void testEmptyColumnInTemplateThrowsError() throws Exception {
-    ReflectionTestUtils.setField(
-        underTest,
-        "printSupplierConfig",
-        "{\"SUPPLIER_A\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\": \"bar\"},\"SUPPLIER_B\":{\"sftpDirectory\":\"foo\",\"encryptionKeyFilename\":\"bar\"}}");
 
     PrintTemplateDto printTemplateDto = new PrintTemplateDto();
     printTemplateDto.setPackCode("packCode1");


### PR DESCRIPTION
# Motivation and Context
The list of print suppliers should be globally configured via the K8S configmap file, which is JSON format.

# What has changed
Ripped out the hacked JSON config held in `application.yml` and replaced with file-based config, mounted by Docker/K8S.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/W9SX2a5n