### PR TITLE
rename survey launch to eq launch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
+      <version>2.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/test/resources/setup_pubsub.sh
+++ b/src/test/resources/setup_pubsub.sh
@@ -23,8 +23,8 @@ curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/rm-inter
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_invalid-case
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_invalid-case_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_invalid-case"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_survey-launch
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_survey-launch_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_survey-launch"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_eq-launch
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_eq-launch_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_eq-launch"}'
 
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_uac-authentication
 curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_uac-authentication_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_uac-authentication"}'


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
"survey launch" is misleading, because a survey is a set of collection exercises, and a set of collection instruments... what we're really talking about is a specific electronic questionnaire launch (which could be either Blaise or EQ).
We need to rename the topic, subscription, listener in case processor and all associated gubbins.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Survey launch has been changed to eq launch in all occurrences
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
`shift-ctrl-f` for surveyLaunch(ed), survey-launch, survey_launch - should be zero occurrences
Build all the services on the ticket, check they all build successfully
Run the ATs using the branch on the ticket
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/hOoco1AN/2752-rename-surveylaunch-to-eqlaunch-5
# Screenshots (if appropriate):
