### PR TITLE
Get rid of old react-document-title in favour of Helmet

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2851,9 +2851,9 @@
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -12343,15 +12343,6 @@
         }
       }
     },
-    "react-document-title": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/react-document-title/-/react-document-title-2.0.3.tgz",
-      "integrity": "sha1-u/kioNcUEvyUgkXkKDskEt9w8rk=",
-      "requires": {
-        "prop-types": "^15.5.6",
-        "react-side-effect": "^1.0.2"
-      }
-    },
     "react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -12366,6 +12357,29 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "dependencies": {
+        "react-side-effect": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+          "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
+        }
+      }
     },
     "react-is": {
       "version": "16.13.1",
@@ -12487,14 +12501,6 @@
         "webpack-dev-server": "3.11.1",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "5.1.4"
-      }
-    },
-    "react-side-effect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.2.0.tgz",
-      "integrity": "sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==",
-      "requires": {
-        "shallowequal": "^1.0.1"
       }
     },
     "read-pkg": {
@@ -12773,9 +12779,9 @@
           }
         },
         "nth-check": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-          "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+          "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
           "requires": {
             "boolbase": "^1.0.0"
           }
@@ -13458,11 +13464,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -14204,9 +14205,9 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -14428,9 +14429,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -14785,9 +14786,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,8 +9,8 @@
     "@testing-library/user-event": "^12.8.3",
     "react": "^17.0.2",
     "react-a11y-announcer": "^2.1.0",
-    "react-document-title": "^2.0.3",
     "react-dom": "^17.0.2",
+    "react-helmet": "^6.1.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "web-vitals": "^1.1.2"

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -5,7 +5,6 @@ import {
   Route,
   useLocation,
 } from "react-router-dom";
-import DocumentTitle from "react-document-title";
 import Home from "./Home";
 import CreateSurvey from "./CreateSurvey";
 import Surveys from "./Surveys";
@@ -13,6 +12,7 @@ import ViewSurvey from "./ViewSurvey";
 import PrintTemplates from "./PrintTemplates";
 import NotFound from "./NotFound";
 import CreatePrintTemplate from "./CreatePrintTemplate";
+import { Helmet } from "react-helmet";
 
 function App() {
   const [loading, setLoading] = useState(true);
@@ -33,22 +33,23 @@ function App() {
   }, []);
 
   return (
-    <DocumentTitle title="Response Operations">
-      <div className="container container--wide page__container">
-        <div className="page__container container container--wide">
-          <main id="main-content" className="page__main">
-            {authorisedActivities.length === 0 && !loading && (
-              <p>User not authorised</p>
-            )}
-            {authorisedActivities.length > 0 && (
-              <Router>
-                <QueryRouting authorisedActivities={authorisedActivities} />
-              </Router>
-            )}
-          </main>
-        </div>
+    <div className="container container--wide page__container">
+      <Helmet>
+        <title>Response Operations</title>
+      </Helmet>
+      <div className="page__container container container--wide">
+        <main id="main-content" className="page__main">
+          {authorisedActivities.length === 0 && !loading && (
+            <p>User not authorised</p>
+          )}
+          {authorisedActivities.length > 0 && (
+            <Router>
+              <QueryRouting authorisedActivities={authorisedActivities} />
+            </Router>
+          )}
+        </main>
       </div>
-    </DocumentTitle>
+    </div>
   );
 }
 
@@ -62,45 +63,31 @@ function QueryRouting(props) {
   return (
     <Switch>
       <Route exact path="/">
-        <DocumentTitle title="Home">
-          <Home authorisedActivities={props.authorisedActivities} />
-        </DocumentTitle>
+        <Home authorisedActivities={props.authorisedActivities} />
       </Route>
       <Route path="/surveys">
-        <DocumentTitle title="Surveys">
-          <Surveys
-            authorisedActivities={props.authorisedActivities}
-            flashMessageUntil={query.get("flashMessageUntil")}
-          />
-        </DocumentTitle>
+        <Surveys
+          authorisedActivities={props.authorisedActivities}
+          flashMessageUntil={query.get("flashMessageUntil")}
+        />
       </Route>
       <Route path="/createsurvey">
-        <DocumentTitle title="Create Survey">
-          <CreateSurvey />
-        </DocumentTitle>
+        <CreateSurvey />
       </Route>
       <Route path="/viewsurvey">
-        <DocumentTitle title="View Survey">
-          <ViewSurvey surveyId={query.get("surveyId")} />
-        </DocumentTitle>
+        <ViewSurvey surveyId={query.get("surveyId")} />
       </Route>
       <Route path="/printtemplates">
-        <DocumentTitle title="View Print Templates">
-          <PrintTemplates
-            authorisedActivities={props.authorisedActivities}
-            flashMessageUntil={query.get("flashMessageUntil")}
-          />
-        </DocumentTitle>
+        <PrintTemplates
+          authorisedActivities={props.authorisedActivities}
+          flashMessageUntil={query.get("flashMessageUntil")}
+        />
       </Route>
       <Route path="/createprinttemplate">
-        <DocumentTitle title="Create Print Template">
-          <CreatePrintTemplate />
-        </DocumentTitle>
+        <CreatePrintTemplate />
       </Route>
       <Route path="*">
-        <DocumentTitle title="Page Not Found">
-          <NotFound />
-        </DocumentTitle>
+        <NotFound />
       </Route>
     </Switch>
   );

--- a/ui/src/CreatePrintTemplate.js
+++ b/ui/src/CreatePrintTemplate.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
 import Announcer from "react-a11y-announcer";
+import { Helmet } from "react-helmet";
 
 function CreatePrintTemplate() {
   const [printSupplier, setPrintSupplier] = useState("");
@@ -420,6 +421,9 @@ function CreatePrintTemplate() {
 
   return (
     <>
+      <Helmet>
+        <title>Create Print Template</title>
+      </Helmet>
       {errorSummary.length > 0 && <ErrorSummary />}
       <h2>Create a Print Template</h2>
       <form onSubmit={validateFormAndCreatePrintTemplate}>

--- a/ui/src/CreateSurvey.js
+++ b/ui/src/CreateSurvey.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
+import { Helmet } from "react-helmet";
 
 function CreateSurvey() {
   let surveyNameInput = null;
@@ -35,6 +36,9 @@ function CreateSurvey() {
 
   return (
     <>
+      <Helmet>
+        <title>Create Survey</title>
+      </Helmet>
       <h2>Create a New Survey</h2>
       <form onSubmit={createSurvey}>
         <div className="field">

--- a/ui/src/Home.js
+++ b/ui/src/Home.js
@@ -1,8 +1,12 @@
 import { Link } from "react-router-dom";
+import { Helmet } from "react-helmet";
 
 function Home(props) {
   return (
     <>
+      <Helmet>
+        <title>Home</title>
+      </Helmet>
       <h2>Home</h2>
       {props.authorisedActivities.includes("LIST_SURVEYS") && (
         <p>

--- a/ui/src/NotFound.js
+++ b/ui/src/NotFound.js
@@ -1,8 +1,12 @@
 import { Link } from "react-router-dom";
+import { Helmet } from "react-helmet";
 
 function NotFound() {
   return (
     <>
+      <Helmet>
+        <title>Page Not Found</title>
+      </Helmet>
       <h2>Page not found</h2>
       <Link to="/">Go to homepage</Link>
     </>

--- a/ui/src/PrintTemplates.js
+++ b/ui/src/PrintTemplates.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import Announcer from "react-a11y-announcer";
+import { Helmet } from "react-helmet";
 
 function PrintTemplates(props) {
   const [tableRows, setTableRows] = useState([]);
@@ -25,6 +26,9 @@ function PrintTemplates(props) {
 
   return (
     <>
+      <Helmet>
+        <title>View Print Templates</title>
+      </Helmet>
       {!props.flashMessageUntil && <Announcer text={"Print Templates"} />}
       {props.flashMessageUntil > Date.now() && (
         <>

--- a/ui/src/Surveys.js
+++ b/ui/src/Surveys.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import Announcer from "react-a11y-announcer";
+import { Helmet } from "react-helmet";
 
 function Surveys(props) {
   const [tableRows, setTableRows] = useState([]);
@@ -23,6 +24,9 @@ function Surveys(props) {
 
   return (
     <>
+      <Helmet>
+        <title>Surveys</title>
+      </Helmet>
       {!props.flashMessageUntil && <Announcer text={"Surveys"} />}
       {props.flashMessageUntil > Date.now() && (
         <>

--- a/ui/src/ViewSurvey.js
+++ b/ui/src/ViewSurvey.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import Announcer from "react-a11y-announcer";
+import { Helmet } from "react-helmet";
 
 function ViewSurvey(props) {
   const [survey, setSurvey] = useState();
@@ -14,6 +15,9 @@ function ViewSurvey(props) {
 
   return (
     <>
+      <Helmet>
+        <title>View Survey</title>
+      </Helmet>
       <h2>View Survey</h2>
       <Announcer text={"View Survey"} />
       {survey && (


### PR DESCRIPTION
# Motivation and Context
Unfortunately `react-document-title` seems to be an abandoned project (last release was 2017).

# What has changed
Migrated to Helmet, which is very widely used.

# How to test?
Check that the page titles still work OK.

# Links
Trello: https://trello.com/c/Hx9rTvmH