### PR TITLE
3036 rops define sample validation via create survey

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/client/SampleDefinitionClient.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/client/SampleDefinitionClient.java
@@ -1,0 +1,60 @@
+package uk.gov.ons.ssdc.responseoperations.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.net.URL;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.validation.ColumnValidator;
+import uk.gov.ons.ssdc.responseoperations.endpoint.SurveyEndpoint;
+import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyType;
+import utility.ObjectMapperFactory;
+
+@Component
+public class SampleDefinitionClient {
+  private static final Logger log = LoggerFactory.getLogger(SurveyEndpoint.class);
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.objectMapper();
+
+  @Value("${sampledefinitions.social}")
+  private String socialSampleDefinitionUrl;
+
+  @Value("${sampledefinitions.business}")
+  private String businessSampleDefinitionUrl;
+
+  @Value("${sampledefinitions.health}")
+  private String healthSampleDefinitionUrl;
+
+  public ColumnValidator[] getColumnValidatorsForSurveyType(SurveyType surveyType) {
+    String sampleDefintionUrll = getSampleDefinitionUrlForSurveyType(surveyType);
+
+    try {
+      URL url = new URL(sampleDefintionUrll);
+      return OBJECT_MAPPER.readValue(url, ColumnValidator[].class);
+    } catch (Exception e) {
+      log.error(
+          String.format(
+              "Failed to successfully get ColumnValidator[] from %s.  Message: %s",
+              sampleDefintionUrll, e.getMessage()));
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot get Sample Definition");
+    }
+  }
+
+  public String getSampleDefinitionUrlForSurveyType(SurveyType surveyType) {
+    switch (surveyType) {
+      case SOCIAL:
+        return socialSampleDefinitionUrl;
+      case BUSINESS:
+        return businessSampleDefinitionUrl;
+      case HEALTH:
+        return healthSampleDefinitionUrl;
+
+      default:
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            String.format("Cannot find surveyType %s to get survey definition"));
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpoint.java
@@ -79,6 +79,7 @@ public class SurveyEndpoint {
     Survey newSurvey = new Survey();
     newSurvey.setId(UUID.randomUUID());
     newSurvey.setName(survey.getName());
+    newSurvey.setSampleWithHeaderRow(true);
 
     SurveyType surveyType = survey.getSurveyType();
     ColumnValidator[] columnValidators =

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpoint.java
@@ -1,9 +1,8 @@
 package uk.gov.ons.ssdc.responseoperations.endpoint;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,76 +16,98 @@ import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.common.validation.ColumnValidator;
-import uk.gov.ons.ssdc.common.validation.MandatoryRule;
-import uk.gov.ons.ssdc.common.validation.Rule;
 import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyDto;
+import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyType;
 import uk.gov.ons.ssdc.responseoperations.model.repository.SurveyRepository;
 import uk.gov.ons.ssdc.responseoperations.security.UserIdentity;
+import utility.ObjectMapperFactory;
+
+import java.net.URL;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping(value = "/api/surveys")
 public class SurveyEndpoint {
-  private final SurveyRepository surveyRepository;
-  private final UserIdentity userIdentity;
+    private static final Logger log = LoggerFactory.getLogger(SurveyEndpoint.class);
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.objectMapper();
+    private final SurveyRepository surveyRepository;
+    private final UserIdentity userIdentity;
 
-  public SurveyEndpoint(SurveyRepository surveyRepository, UserIdentity userIdentity) {
-    this.surveyRepository = surveyRepository;
-    this.userIdentity = userIdentity;
-  }
-
-  @GetMapping
-  public List<SurveyDto> getSurveys(
-      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.LIST_SURVEYS);
-
-    List<Survey> surveys = surveyRepository.findAll();
-
-    // TODO: should we filter out the surveys that the user has no permissions on?
-    return surveys.stream().map(this::mapSurvey).collect(Collectors.toList());
-  }
-
-  @GetMapping(value = "/{id}")
-  public SurveyDto getSurvey(@PathVariable("id") UUID id) {
-    // TODO: should we stop unauthorised users getting survey name or is it over the top?
-
-    Optional<Survey> optionalSurvey = surveyRepository.findById(id);
-
-    if (!optionalSurvey.isPresent()) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    public SurveyEndpoint(SurveyRepository surveyRepository, UserIdentity userIdentity) {
+        this.surveyRepository = surveyRepository;
+        this.userIdentity = userIdentity;
     }
 
-    return mapSurvey(optionalSurvey.get());
-  }
+    @GetMapping
+    public List<SurveyDto> getSurveys(
+            @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+        userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.LIST_SURVEYS);
 
-  @PostMapping
-  public ResponseEntity createSurvey(
-      @RequestBody SurveyDto survey,
-      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-    userIdentity.checkGlobalUserPermission(
-        userEmail, UserGroupAuthorisedActivityType.CREATE_SURVEY);
+        List<Survey> surveys = surveyRepository.findAll();
 
-    Survey newSurvey = new Survey();
-    newSurvey.setId(UUID.randomUUID());
-    newSurvey.setName(survey.getName());
-    newSurvey.setSampleSeparator(',');
+        // TODO: should we filter out the surveys that the user has no permissions on?
+        return surveys.stream().map(this::mapSurvey).collect(Collectors.toList());
+    }
 
-    // TODO: This is just a placeholder. This needs to be replaced with real columns/rules
-    newSurvey.setSampleValidationRules(
-        new ColumnValidator[] {
-          new ColumnValidator("DUMMY_COLUMN", false, new Rule[] {new MandatoryRule()})
-        });
+    @GetMapping(value = "/{id}")
+    public SurveyDto getSurvey(@PathVariable("id") UUID id) {
+        // TODO: should we stop unauthorised users getting survey name or is it over the top?
 
-    // TODO: This is just a placeholder. This needs to be replaced with real URL
-    newSurvey.setSampleDefinitionUrl("http://dummy");
+        Optional<Survey> optionalSurvey = surveyRepository.findById(id);
 
-    surveyRepository.saveAndFlush(newSurvey);
-    return new ResponseEntity(HttpStatus.CREATED);
-  }
+        if (!optionalSurvey.isPresent()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
 
-  private SurveyDto mapSurvey(Survey survey) {
-    SurveyDto dto = new SurveyDto();
-    dto.setId(survey.getId().toString());
-    dto.setName(survey.getName());
-    return dto;
-  }
+        return mapSurvey(optionalSurvey.get());
+    }
+
+    @GetMapping(value = "/surveyTypes")
+    public String[] getSurveyTypes() {
+        return EnumSet.allOf(SurveyType.class).stream().map(Enum::toString).toArray(String[]::new);
+    }
+
+    @PostMapping
+    public ResponseEntity createSurvey(
+            @RequestBody SurveyDto survey,
+            @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+        userIdentity.checkGlobalUserPermission(
+                userEmail, UserGroupAuthorisedActivityType.CREATE_SURVEY);
+
+        Survey newSurvey = new Survey();
+        newSurvey.setId(UUID.randomUUID());
+        newSurvey.setName(survey.getName());
+
+        SurveyType surveyType = survey.getSurveyType();
+        ColumnValidator[] columnValidators = getColumnValidatorsFromUrl(surveyType.getSampleDefintionUrll());
+        newSurvey.setSampleValidationRules(columnValidators);
+
+        newSurvey.setSampleDefinitionUrl(surveyType.getSampleDefintionUrll());
+        newSurvey.setSampleSeparator(',');
+        surveyRepository.saveAndFlush(newSurvey);
+
+        return new ResponseEntity(HttpStatus.CREATED);
+    }
+
+    private ColumnValidator[] getColumnValidatorsFromUrl(String sampleDefintionUrll) {
+        try {
+            URL url = new URL(sampleDefintionUrll);
+            return  OBJECT_MAPPER.readValue(url, ColumnValidator[].class);
+        } catch (Exception e){
+            log.error(String.format("Failed to successfully get ColumnValidator[] from %s.  Message: %s",
+                    sampleDefintionUrll));
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot get Sample Definition");
+        }
+    }
+
+    private SurveyDto mapSurvey(Survey survey) {
+        SurveyDto dto = new SurveyDto();
+        dto.setId(survey.getId().toString());
+        dto.setName(survey.getName());
+        return dto;
+    }
 }

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpoint.java
@@ -1,8 +1,10 @@
 package uk.gov.ons.ssdc.responseoperations.endpoint;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,98 +18,85 @@ import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.common.validation.ColumnValidator;
+import uk.gov.ons.ssdc.responseoperations.client.SampleDefinitionClient;
 import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyDto;
 import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyType;
 import uk.gov.ons.ssdc.responseoperations.model.repository.SurveyRepository;
 import uk.gov.ons.ssdc.responseoperations.security.UserIdentity;
-import utility.ObjectMapperFactory;
-
-import java.net.URL;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping(value = "/api/surveys")
 public class SurveyEndpoint {
-    private static final Logger log = LoggerFactory.getLogger(SurveyEndpoint.class);
-    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.objectMapper();
-    private final SurveyRepository surveyRepository;
-    private final UserIdentity userIdentity;
+  private final SurveyRepository surveyRepository;
+  private final UserIdentity userIdentity;
+  private final SampleDefinitionClient sampleDefinitionClient;
 
-    public SurveyEndpoint(SurveyRepository surveyRepository, UserIdentity userIdentity) {
-        this.surveyRepository = surveyRepository;
-        this.userIdentity = userIdentity;
+  public SurveyEndpoint(
+      SurveyRepository surveyRepository,
+      UserIdentity userIdentity,
+      SampleDefinitionClient sampleDefinitionClient) {
+    this.surveyRepository = surveyRepository;
+    this.userIdentity = userIdentity;
+    this.sampleDefinitionClient = sampleDefinitionClient;
+  }
+
+  @GetMapping
+  public List<SurveyDto> getSurveys(
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.LIST_SURVEYS);
+
+    List<Survey> surveys = surveyRepository.findAll();
+
+    // TODO: should we filter out the surveys that the user has no permissions on?
+    return surveys.stream().map(this::mapSurvey).collect(Collectors.toList());
+  }
+
+  @GetMapping(value = "/{id}")
+  public SurveyDto getSurvey(@PathVariable("id") UUID id) {
+    // TODO: should we stop unauthorised users getting survey name or is it over the top?
+
+    Optional<Survey> optionalSurvey = surveyRepository.findById(id);
+
+    if (!optionalSurvey.isPresent()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
 
-    @GetMapping
-    public List<SurveyDto> getSurveys(
-            @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-        userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.LIST_SURVEYS);
+    return mapSurvey(optionalSurvey.get());
+  }
 
-        List<Survey> surveys = surveyRepository.findAll();
+  @GetMapping(value = "/surveyTypes")
+  public String[] getSurveyTypes() {
+    return EnumSet.allOf(SurveyType.class).stream().map(Enum::toString).toArray(String[]::new);
+  }
 
-        // TODO: should we filter out the surveys that the user has no permissions on?
-        return surveys.stream().map(this::mapSurvey).collect(Collectors.toList());
-    }
+  @PostMapping
+  public ResponseEntity createSurvey(
+      @RequestBody SurveyDto survey,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(
+        userEmail, UserGroupAuthorisedActivityType.CREATE_SURVEY);
 
-    @GetMapping(value = "/{id}")
-    public SurveyDto getSurvey(@PathVariable("id") UUID id) {
-        // TODO: should we stop unauthorised users getting survey name or is it over the top?
+    Survey newSurvey = new Survey();
+    newSurvey.setId(UUID.randomUUID());
+    newSurvey.setName(survey.getName());
 
-        Optional<Survey> optionalSurvey = surveyRepository.findById(id);
+    SurveyType surveyType = survey.getSurveyType();
+    ColumnValidator[] columnValidators =
+        sampleDefinitionClient.getColumnValidatorsForSurveyType(surveyType);
+    newSurvey.setSampleValidationRules(columnValidators);
 
-        if (!optionalSurvey.isPresent()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
+    newSurvey.setSampleDefinitionUrl(
+        sampleDefinitionClient.getSampleDefinitionUrlForSurveyType(surveyType));
+    newSurvey.setSampleSeparator(',');
+    surveyRepository.saveAndFlush(newSurvey);
 
-        return mapSurvey(optionalSurvey.get());
-    }
+    return new ResponseEntity(HttpStatus.CREATED);
+  }
 
-    @GetMapping(value = "/surveyTypes")
-    public String[] getSurveyTypes() {
-        return EnumSet.allOf(SurveyType.class).stream().map(Enum::toString).toArray(String[]::new);
-    }
-
-    @PostMapping
-    public ResponseEntity createSurvey(
-            @RequestBody SurveyDto survey,
-            @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-        userIdentity.checkGlobalUserPermission(
-                userEmail, UserGroupAuthorisedActivityType.CREATE_SURVEY);
-
-        Survey newSurvey = new Survey();
-        newSurvey.setId(UUID.randomUUID());
-        newSurvey.setName(survey.getName());
-
-        SurveyType surveyType = survey.getSurveyType();
-        ColumnValidator[] columnValidators = getColumnValidatorsFromUrl(surveyType.getSampleDefintionUrll());
-        newSurvey.setSampleValidationRules(columnValidators);
-
-        newSurvey.setSampleDefinitionUrl(surveyType.getSampleDefintionUrll());
-        newSurvey.setSampleSeparator(',');
-        surveyRepository.saveAndFlush(newSurvey);
-
-        return new ResponseEntity(HttpStatus.CREATED);
-    }
-
-    private ColumnValidator[] getColumnValidatorsFromUrl(String sampleDefintionUrll) {
-        try {
-            URL url = new URL(sampleDefintionUrll);
-            return  OBJECT_MAPPER.readValue(url, ColumnValidator[].class);
-        } catch (Exception e){
-            log.error(String.format("Failed to successfully get ColumnValidator[] from %s.  Message: %s",
-                    sampleDefintionUrll));
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot get Sample Definition");
-        }
-    }
-
-    private SurveyDto mapSurvey(Survey survey) {
-        SurveyDto dto = new SurveyDto();
-        dto.setId(survey.getId().toString());
-        dto.setName(survey.getName());
-        return dto;
-    }
+  private SurveyDto mapSurvey(Survey survey) {
+    SurveyDto dto = new SurveyDto();
+    dto.setId(survey.getId().toString());
+    dto.setName(survey.getName());
+    return dto;
+  }
 }

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/model/dto/ui/SurveyDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/model/dto/ui/SurveyDto.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class SurveyDto {
   private String id;
   private String name;
+  private SurveyType surveyType;
 }

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/model/dto/ui/SurveyType.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/model/dto/ui/SurveyType.java
@@ -1,0 +1,18 @@
+package uk.gov.ons.ssdc.responseoperations.model.dto.ui;
+
+public enum SurveyType {
+
+    SOCIAL("https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/social/0.1.0/social.json"),
+    BUSINESS("https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/business/0.1.0-DRAFT/business.json"),
+    HEALTH("https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/sis/0.1.0-DRAFT/sis.json");
+
+    private final String sampleDefinitionUrl;
+
+    SurveyType(String sampleDefinitionUrl) {
+        this.sampleDefinitionUrl = sampleDefinitionUrl;
+    }
+
+    public String getSampleDefintionUrll() {
+        return sampleDefinitionUrl;
+    }
+}

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/model/dto/ui/SurveyType.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/model/dto/ui/SurveyType.java
@@ -1,18 +1,7 @@
 package uk.gov.ons.ssdc.responseoperations.model.dto.ui;
 
 public enum SurveyType {
-
-    SOCIAL("https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/social/0.1.0/social.json"),
-    BUSINESS("https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/business/0.1.0-DRAFT/business.json"),
-    HEALTH("https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/sis/0.1.0-DRAFT/sis.json");
-
-    private final String sampleDefinitionUrl;
-
-    SurveyType(String sampleDefinitionUrl) {
-        this.sampleDefinitionUrl = sampleDefinitionUrl;
-    }
-
-    public String getSampleDefintionUrll() {
-        return sampleDefinitionUrl;
-    }
+  SOCIAL,
+  BUSINESS,
+  HEALTH;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,12 @@ management:
 
 iapaudience: DUMMY
 
+sampledefinitions:
+  social: https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/social/0.1.0/social.json
+  business: https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/business/0.1.0-DRAFT/business.json
+  health: https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/sis/0.1.0-DRAFT/sis.json
+
+
 # TODO: Remove this before releasing to prod
 dummyuseridentity: dummy@fake-email.com
 

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/client/SampleDefinitionClientTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/client/SampleDefinitionClientTest.java
@@ -1,0 +1,55 @@
+package uk.gov.ons.ssdc.responseoperations.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.ssdc.common.validation.ColumnValidator;
+import uk.gov.ons.ssdc.common.validation.Rule;
+import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyType;
+
+class SampleDefinitionClientTest {
+
+  @Test
+  public void testGetSampleDefinitionUrl() {
+    SampleDefinitionClient underTest = new SampleDefinitionClient();
+    ReflectionTestUtils.setField(underTest, "socialSampleDefinitionUrl", "https//social.url");
+    ReflectionTestUtils.setField(underTest, "businessSampleDefinitionUrl", "https//business.url");
+    ReflectionTestUtils.setField(underTest, "healthSampleDefinitionUrl", "https//health.url");
+
+    assertThat(underTest.getSampleDefinitionUrlForSurveyType(SurveyType.SOCIAL))
+        .isEqualTo("https//social.url");
+    assertThat(underTest.getSampleDefinitionUrlForSurveyType(SurveyType.BUSINESS))
+        .isEqualTo("https//business.url");
+    assertThat(underTest.getSampleDefinitionUrlForSurveyType(SurveyType.HEALTH))
+        .isEqualTo("https//health.url");
+  }
+
+  @Test
+  public void testGetColumnValidators() throws MalformedURLException {
+    SampleDefinitionClient underTest = new SampleDefinitionClient();
+    String fileUrl =
+        new File("src/test/resources/sampleDefinitionFiles/social_test.json")
+            .toURI()
+            .toURL()
+            .toString();
+
+    ReflectionTestUtils.setField(underTest, "socialSampleDefinitionUrl", fileUrl);
+
+    ColumnValidator[] actualColumnValidators =
+        underTest.getColumnValidatorsForSurveyType(SurveyType.SOCIAL);
+    assertThat(actualColumnValidators).hasSize(2);
+
+    ColumnValidator questionnaireColumnValidator = actualColumnValidators[0];
+    assertThat(questionnaireColumnValidator.getColumnName()).isEqualTo("questionnaire");
+
+    Rule[] questionnaireRules = actualColumnValidators[0].getRules();
+    assertThat(questionnaireRules).hasSize(2);
+    assertThat(questionnaireRules[0].getClass().getName())
+        .isEqualTo("uk.gov.ons.ssdc.common.validation.MandatoryRule");
+    assertThat(questionnaireRules[1].getClass().getName())
+        .isEqualTo("uk.gov.ons.ssdc.common.validation.LengthRule");
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpointIT.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,129 +32,126 @@ import uk.gov.ons.ssdc.responseoperations.test_utils.UserPermissionHelper;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 public class SurveyEndpointIT {
-    @Autowired
-    private SurveyRepository surveyRepository;
-    @Autowired
-    private UserPermissionHelper userPermissionHelper;
+  @Autowired private SurveyRepository surveyRepository;
+  @Autowired private UserPermissionHelper userPermissionHelper;
 
-    @LocalServerPort
-    private int port;
+  @LocalServerPort private int port;
 
-    @BeforeEach
-    @Transactional
-    public void setUp() {
-        userPermissionHelper.clearDown();
-        surveyRepository.deleteAllInBatch();
-    }
+  @BeforeEach
+  @Transactional
+  public void setUp() {
+    userPermissionHelper.clearDown();
+    surveyRepository.deleteAllInBatch();
+  }
 
-    @Test
-    public void getSurveys() {
-        userPermissionHelper.setUpTestUserPermission(UserGroupAuthorisedActivityType.LIST_SURVEYS);
+  @Test
+  public void getSurveys() {
+    userPermissionHelper.setUpTestUserPermission(UserGroupAuthorisedActivityType.LIST_SURVEYS);
 
-        Survey survey = new Survey();
-        survey.setId(UUID.randomUUID());
-        survey.setName("Test survey");
-        survey.setSampleSeparator(',');
-        survey.setSampleValidationRules(
-                new ColumnValidator[]{
-                        new ColumnValidator("DUMMY_COLUMN", false, new Rule[]{new MandatoryRule()})
-                });
-        survey.setSampleDefinitionUrl("http://dummy");
-        surveyRepository.saveAndFlush(survey);
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+    survey.setName("Test survey");
+    survey.setSampleSeparator(',');
+    survey.setSampleValidationRules(
+        new ColumnValidator[] {
+          new ColumnValidator("DUMMY_COLUMN", false, new Rule[] {new MandatoryRule()})
+        });
+    survey.setSampleDefinitionUrl("http://dummy");
+    surveyRepository.saveAndFlush(survey);
 
-        RestTemplate restTemplate = new RestTemplate();
-        String url = "http://localhost:" + port + "/api/surveys";
-        ResponseEntity<SurveyDto[]> foundSurveysResponse =
-                restTemplate.getForEntity(url, SurveyDto[].class);
+    RestTemplate restTemplate = new RestTemplate();
+    String url = "http://localhost:" + port + "/api/surveys";
+    ResponseEntity<SurveyDto[]> foundSurveysResponse =
+        restTemplate.getForEntity(url, SurveyDto[].class);
 
-        SurveyDto[] actualSurveys = foundSurveysResponse.getBody();
-        assertThat(actualSurveys.length).isEqualTo(1);
-        assertThat(actualSurveys[0].getName()).isEqualTo("Test survey");
-    }
+    SurveyDto[] actualSurveys = foundSurveysResponse.getBody();
+    assertThat(actualSurveys.length).isEqualTo(1);
+    assertThat(actualSurveys[0].getName()).isEqualTo("Test survey");
+  }
 
-    @Test
-    public void getSurveysForbidden() {
-        RestTemplate restTemplate = new RestTemplate();
-        String url = "http://localhost:" + port + "/api/surveys";
-        HttpClientErrorException thrown =
-                assertThrows(
-                        HttpClientErrorException.class,
-                        () -> restTemplate.getForEntity(url, SurveyDto[].class));
+  @Test
+  public void getSurveysForbidden() {
+    RestTemplate restTemplate = new RestTemplate();
+    String url = "http://localhost:" + port + "/api/surveys";
+    HttpClientErrorException thrown =
+        assertThrows(
+            HttpClientErrorException.class,
+            () -> restTemplate.getForEntity(url, SurveyDto[].class));
 
-        assertThat(thrown.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-    }
+    assertThat(thrown.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
 
-    @Test
-    public void getSurvey() {
-        Survey survey = new Survey();
-        survey.setId(UUID.randomUUID());
-        survey.setName("Test survey");
-        survey.setSampleSeparator(',');
-        survey.setSampleValidationRules(
-                new ColumnValidator[]{
-                        new ColumnValidator("DUMMY_COLUMN", false, new Rule[]{new MandatoryRule()})
-                });
-        survey.setSampleDefinitionUrl("http://dummy");
-        surveyRepository.saveAndFlush(survey);
+  @Test
+  public void getSurvey() {
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+    survey.setName("Test survey");
+    survey.setSampleSeparator(',');
+    survey.setSampleValidationRules(
+        new ColumnValidator[] {
+          new ColumnValidator("DUMMY_COLUMN", false, new Rule[] {new MandatoryRule()})
+        });
+    survey.setSampleDefinitionUrl("http://dummy");
+    surveyRepository.saveAndFlush(survey);
 
-        RestTemplate restTemplate = new RestTemplate();
-        String url = "http://localhost:" + port + "/api/surveys/" + survey.getId();
-        ResponseEntity<SurveyDto> foundSurveyResponse = restTemplate.getForEntity(url, SurveyDto.class);
+    RestTemplate restTemplate = new RestTemplate();
+    String url = "http://localhost:" + port + "/api/surveys/" + survey.getId();
+    ResponseEntity<SurveyDto> foundSurveyResponse = restTemplate.getForEntity(url, SurveyDto.class);
 
-        SurveyDto actualSurvey = foundSurveyResponse.getBody();
-        assertThat(actualSurvey.getName()).isEqualTo("Test survey");
-    }
+    SurveyDto actualSurvey = foundSurveyResponse.getBody();
+    assertThat(actualSurvey.getName()).isEqualTo("Test survey");
+  }
 
-    @Test
-    public void createSurvey() {
-        userPermissionHelper.setUpTestUserPermission(UserGroupAuthorisedActivityType.CREATE_SURVEY);
+  @Test
+  public void createSurvey() {
+    userPermissionHelper.setUpTestUserPermission(UserGroupAuthorisedActivityType.CREATE_SURVEY);
 
-        SurveyDto survey = new SurveyDto();
-        survey.setName("Test survey");
-        SurveyType testSurveyType = SurveyType.BUSINESS;
-        survey.setSurveyType(testSurveyType);
+    SurveyDto survey = new SurveyDto();
+    survey.setName("Test survey");
+    SurveyType testSurveyType = SurveyType.SOCIAL;
+    survey.setSurveyType(testSurveyType);
 
-        RestTemplate restTemplate = new RestTemplate();
-        String url = "http://localhost:" + port + "/api/surveys";
-        ResponseEntity response = restTemplate.postForEntity(url, survey, SurveyDto.class);
+    RestTemplate restTemplate = new RestTemplate();
+    String url = "http://localhost:" + port + "/api/surveys";
+    ResponseEntity response = restTemplate.postForEntity(url, survey, SurveyDto.class);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
-        List<Survey> allSurveys = surveyRepository.findAll();
-        assertThat(allSurveys.size()).isEqualTo(1);
-        assertThat(allSurveys.get(0).getName()).isEqualTo("Test survey");
-        assertThat(allSurveys.get(1).getSampleValidationRules()).hasSizeGreaterThan(0);
-    }
+    List<Survey> allSurveys = surveyRepository.findAll();
+    assertThat(allSurveys.size()).isEqualTo(1);
+    assertThat(allSurveys.get(0).getName()).isEqualTo("Test survey");
+    assertThat(allSurveys.get(0).getSampleValidationRules()).hasSize(2);
+    assertThat(allSurveys.get(0).getSampleValidationRules()[1].getColumnName())
+        .isEqualTo("sampleUnitRef");
+  }
 
+  @Test
+  public void createSurveyForbidden() {
+    SurveyDto survey = new SurveyDto();
+    survey.setName("Test survey");
 
+    RestTemplate restTemplate = new RestTemplate();
+    String url = "http://localhost:" + port + "/api/surveys";
 
-    @Test
-    public void createSurveyForbidden() {
-        SurveyDto survey = new SurveyDto();
-        survey.setName("Test survey");
+    HttpClientErrorException thrown =
+        assertThrows(
+            HttpClientErrorException.class,
+            () -> restTemplate.postForEntity(url, survey, SurveyDto.class));
 
-        RestTemplate restTemplate = new RestTemplate();
-        String url = "http://localhost:" + port + "/api/surveys";
+    assertThat(thrown.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
 
-        HttpClientErrorException thrown =
-                assertThrows(
-                        HttpClientErrorException.class,
-                        () -> restTemplate.postForEntity(url, survey, SurveyDto.class));
+  @Test
+  public void testGetSurveyTypes() {
+    RestTemplate restTemplate = new RestTemplate();
+    String url = "http://localhost:" + port + "/api/surveys/surveyTypes";
+    ResponseEntity<SurveyType[]> foundSurveysResponse =
+        restTemplate.getForEntity(url, SurveyType[].class);
 
-        assertThat(thrown.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-    }
-
-    @Test
-    public void testGetSurveyTypes() {
-        RestTemplate restTemplate = new RestTemplate();
-        String url = "http://localhost:" + port + "/api/surveys/surveyTypes";
-        ResponseEntity<SurveyType[]> foundSurveysResponse =
-                restTemplate.getForEntity(url, SurveyType[].class);
-
-        SurveyType[] actualSurveyTypes = foundSurveysResponse.getBody();
-        assertThat(actualSurveyTypes.length).isEqualTo(3);
-        assertThat(actualSurveyTypes[0]).isEqualTo(SurveyType.SOCIAL);
-        assertThat(actualSurveyTypes[1]).isEqualTo(SurveyType.BUSINESS);
-        assertThat(actualSurveyTypes[2]).isEqualTo(SurveyType.HEALTH);
-    }
+    SurveyType[] actualSurveyTypes = foundSurveysResponse.getBody();
+    assertThat(actualSurveyTypes.length).isEqualTo(3);
+    assertThat(actualSurveyTypes[0]).isEqualTo(SurveyType.SOCIAL);
+    assertThat(actualSurveyTypes[1]).isEqualTo(SurveyType.BUSINESS);
+    assertThat(actualSurveyTypes[2]).isEqualTo(SurveyType.HEALTH);
+  }
 }

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpointIT.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,7 @@ import uk.gov.ons.ssdc.common.validation.ColumnValidator;
 import uk.gov.ons.ssdc.common.validation.MandatoryRule;
 import uk.gov.ons.ssdc.common.validation.Rule;
 import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyDto;
+import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyType;
 import uk.gov.ons.ssdc.responseoperations.model.repository.SurveyRepository;
 import uk.gov.ons.ssdc.responseoperations.test_utils.UserPermissionHelper;
 
@@ -31,107 +33,129 @@ import uk.gov.ons.ssdc.responseoperations.test_utils.UserPermissionHelper;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 public class SurveyEndpointIT {
-  @Autowired private SurveyRepository surveyRepository;
-  @Autowired private UserPermissionHelper userPermissionHelper;
+    @Autowired
+    private SurveyRepository surveyRepository;
+    @Autowired
+    private UserPermissionHelper userPermissionHelper;
 
-  @LocalServerPort private int port;
+    @LocalServerPort
+    private int port;
 
-  @BeforeEach
-  @Transactional
-  public void setUp() {
-    userPermissionHelper.clearDown();
-    surveyRepository.deleteAllInBatch();
-  }
+    @BeforeEach
+    @Transactional
+    public void setUp() {
+        userPermissionHelper.clearDown();
+        surveyRepository.deleteAllInBatch();
+    }
 
-  @Test
-  public void getSurveys() {
-    userPermissionHelper.setUpTestUserPermission(UserGroupAuthorisedActivityType.LIST_SURVEYS);
+    @Test
+    public void getSurveys() {
+        userPermissionHelper.setUpTestUserPermission(UserGroupAuthorisedActivityType.LIST_SURVEYS);
 
-    Survey survey = new Survey();
-    survey.setId(UUID.randomUUID());
-    survey.setName("Test survey");
-    survey.setSampleSeparator(',');
-    survey.setSampleValidationRules(
-        new ColumnValidator[] {
-          new ColumnValidator("DUMMY_COLUMN", false, new Rule[] {new MandatoryRule()})
-        });
-    survey.setSampleDefinitionUrl("http://dummy");
-    surveyRepository.saveAndFlush(survey);
+        Survey survey = new Survey();
+        survey.setId(UUID.randomUUID());
+        survey.setName("Test survey");
+        survey.setSampleSeparator(',');
+        survey.setSampleValidationRules(
+                new ColumnValidator[]{
+                        new ColumnValidator("DUMMY_COLUMN", false, new Rule[]{new MandatoryRule()})
+                });
+        survey.setSampleDefinitionUrl("http://dummy");
+        surveyRepository.saveAndFlush(survey);
 
-    RestTemplate restTemplate = new RestTemplate();
-    String url = "http://localhost:" + port + "/api/surveys";
-    ResponseEntity<SurveyDto[]> foundSurveysResponse =
-        restTemplate.getForEntity(url, SurveyDto[].class);
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://localhost:" + port + "/api/surveys";
+        ResponseEntity<SurveyDto[]> foundSurveysResponse =
+                restTemplate.getForEntity(url, SurveyDto[].class);
 
-    SurveyDto[] actualSurveys = foundSurveysResponse.getBody();
-    assertThat(actualSurveys.length).isEqualTo(1);
-    assertThat(actualSurveys[0].getName()).isEqualTo("Test survey");
-  }
+        SurveyDto[] actualSurveys = foundSurveysResponse.getBody();
+        assertThat(actualSurveys.length).isEqualTo(1);
+        assertThat(actualSurveys[0].getName()).isEqualTo("Test survey");
+    }
 
-  @Test
-  public void getSurveysForbidden() {
-    RestTemplate restTemplate = new RestTemplate();
-    String url = "http://localhost:" + port + "/api/surveys";
-    HttpClientErrorException thrown =
-        assertThrows(
-            HttpClientErrorException.class,
-            () -> restTemplate.getForEntity(url, SurveyDto[].class));
+    @Test
+    public void getSurveysForbidden() {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://localhost:" + port + "/api/surveys";
+        HttpClientErrorException thrown =
+                assertThrows(
+                        HttpClientErrorException.class,
+                        () -> restTemplate.getForEntity(url, SurveyDto[].class));
 
-    assertThat(thrown.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-  }
+        assertThat(thrown.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
 
-  @Test
-  public void getSurvey() {
-    Survey survey = new Survey();
-    survey.setId(UUID.randomUUID());
-    survey.setName("Test survey");
-    survey.setSampleSeparator(',');
-    survey.setSampleValidationRules(
-        new ColumnValidator[] {
-          new ColumnValidator("DUMMY_COLUMN", false, new Rule[] {new MandatoryRule()})
-        });
-    survey.setSampleDefinitionUrl("http://dummy");
-    surveyRepository.saveAndFlush(survey);
+    @Test
+    public void getSurvey() {
+        Survey survey = new Survey();
+        survey.setId(UUID.randomUUID());
+        survey.setName("Test survey");
+        survey.setSampleSeparator(',');
+        survey.setSampleValidationRules(
+                new ColumnValidator[]{
+                        new ColumnValidator("DUMMY_COLUMN", false, new Rule[]{new MandatoryRule()})
+                });
+        survey.setSampleDefinitionUrl("http://dummy");
+        surveyRepository.saveAndFlush(survey);
 
-    RestTemplate restTemplate = new RestTemplate();
-    String url = "http://localhost:" + port + "/api/surveys/" + survey.getId();
-    ResponseEntity<SurveyDto> foundSurveyResponse = restTemplate.getForEntity(url, SurveyDto.class);
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://localhost:" + port + "/api/surveys/" + survey.getId();
+        ResponseEntity<SurveyDto> foundSurveyResponse = restTemplate.getForEntity(url, SurveyDto.class);
 
-    SurveyDto actualSurvey = foundSurveyResponse.getBody();
-    assertThat(actualSurvey.getName()).isEqualTo("Test survey");
-  }
+        SurveyDto actualSurvey = foundSurveyResponse.getBody();
+        assertThat(actualSurvey.getName()).isEqualTo("Test survey");
+    }
 
-  @Test
-  public void createSurvey() {
-    userPermissionHelper.setUpTestUserPermission(UserGroupAuthorisedActivityType.CREATE_SURVEY);
+    @Test
+    public void createSurvey() {
+        userPermissionHelper.setUpTestUserPermission(UserGroupAuthorisedActivityType.CREATE_SURVEY);
 
-    SurveyDto survey = new SurveyDto();
-    survey.setName("Test survey");
+        SurveyDto survey = new SurveyDto();
+        survey.setName("Test survey");
+        SurveyType testSurveyType = SurveyType.BUSINESS;
+        survey.setSurveyType(testSurveyType);
 
-    RestTemplate restTemplate = new RestTemplate();
-    String url = "http://localhost:" + port + "/api/surveys";
-    ResponseEntity response = restTemplate.postForEntity(url, survey, SurveyDto.class);
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://localhost:" + port + "/api/surveys";
+        ResponseEntity response = restTemplate.postForEntity(url, survey, SurveyDto.class);
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
-    List<Survey> allSurveys = surveyRepository.findAll();
-    assertThat(allSurveys.size()).isEqualTo(1);
-    assertThat(allSurveys.get(0).getName()).isEqualTo("Test survey");
-  }
+        List<Survey> allSurveys = surveyRepository.findAll();
+        assertThat(allSurveys.size()).isEqualTo(1);
+        assertThat(allSurveys.get(0).getName()).isEqualTo("Test survey");
+        assertThat(allSurveys.get(1).getSampleValidationRules()).hasSizeGreaterThan(0);
+    }
 
-  @Test
-  public void createSurveyForbidden() {
-    SurveyDto survey = new SurveyDto();
-    survey.setName("Test survey");
 
-    RestTemplate restTemplate = new RestTemplate();
-    String url = "http://localhost:" + port + "/api/surveys";
 
-    HttpClientErrorException thrown =
-        assertThrows(
-            HttpClientErrorException.class,
-            () -> restTemplate.postForEntity(url, survey, SurveyDto.class));
+    @Test
+    public void createSurveyForbidden() {
+        SurveyDto survey = new SurveyDto();
+        survey.setName("Test survey");
 
-    assertThat(thrown.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-  }
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://localhost:" + port + "/api/surveys";
+
+        HttpClientErrorException thrown =
+                assertThrows(
+                        HttpClientErrorException.class,
+                        () -> restTemplate.postForEntity(url, survey, SurveyDto.class));
+
+        assertThat(thrown.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    public void testGetSurveyTypes() {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://localhost:" + port + "/api/surveys/surveyTypes";
+        ResponseEntity<SurveyType[]> foundSurveysResponse =
+                restTemplate.getForEntity(url, SurveyType[].class);
+
+        SurveyType[] actualSurveyTypes = foundSurveysResponse.getBody();
+        assertThat(actualSurveyTypes.length).isEqualTo(3);
+        assertThat(actualSurveyTypes[0]).isEqualTo(SurveyType.SOCIAL);
+        assertThat(actualSurveyTypes[1]).isEqualTo(SurveyType.BUSINESS);
+        assertThat(actualSurveyTypes[2]).isEqualTo(SurveyType.HEALTH);
+    }
 }

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/SurveyEndpointTest.java
@@ -14,11 +14,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.ons.ssdc.responseoperations.test_utils.JsonHelper.asJsonString;
 
-import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,14 +24,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.common.validation.ColumnValidator;
+import uk.gov.ons.ssdc.responseoperations.client.SampleDefinitionClient;
 import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyDto;
 import uk.gov.ons.ssdc.responseoperations.model.dto.ui.SurveyType;
 import uk.gov.ons.ssdc.responseoperations.model.repository.SurveyRepository;
@@ -42,113 +39,103 @@ import uk.gov.ons.ssdc.responseoperations.security.UserIdentity;
 @ExtendWith(MockitoExtension.class)
 class SurveyEndpointTest {
 
-    @Mock
-    private SurveyRepository surveyRepository;
+  @Mock private SurveyRepository surveyRepository;
 
-    @Mock
-    private UserIdentity userIdentity;
+  @Mock private UserIdentity userIdentity;
 
-    @InjectMocks
-    private SurveyEndpoint underTest;
+  @Mock private SampleDefinitionClient sampleDefinitionClient;
 
-    private MockMvc mockMvc;
+  @InjectMocks private SurveyEndpoint underTest;
 
-    @BeforeEach
-    public void setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(underTest).build();
-    }
+  private MockMvc mockMvc;
 
-    @Test
-    public void testGetAllSurveys() throws Exception {
+  @BeforeEach
+  public void setUp() {
+    mockMvc = MockMvcBuilders.standaloneSetup(underTest).build();
+  }
 
-        // Given
-        Survey survey = new Survey();
-        survey.setId(UUID.randomUUID());
-        survey.setName("Test survey");
-        when(surveyRepository.findAll()).thenReturn(List.of(survey));
+  @Test
+  public void testGetAllSurveys() throws Exception {
 
-        // When
-        mockMvc
-                .perform(get("/api/surveys").accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(handler().handlerType(SurveyEndpoint.class))
-                .andExpect(handler().methodName("getSurveys"))
-                .andExpect(jsonPath("$[0].id", is(survey.getId().toString())))
-                .andExpect(jsonPath("$[0].name", is("Test survey")));
+    // Given
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+    survey.setName("Test survey");
+    when(surveyRepository.findAll()).thenReturn(List.of(survey));
 
-        // Then
-        verify(userIdentity)
-                .checkGlobalUserPermission(anyString(), eq(UserGroupAuthorisedActivityType.LIST_SURVEYS));
-    }
+    // When
+    mockMvc
+        .perform(get("/api/surveys").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(handler().handlerType(SurveyEndpoint.class))
+        .andExpect(handler().methodName("getSurveys"))
+        .andExpect(jsonPath("$[0].id", is(survey.getId().toString())))
+        .andExpect(jsonPath("$[0].name", is("Test survey")));
 
-    @Test
-    public void testGetSurvey() throws Exception {
-        // Given
-        Survey survey = new Survey();
-        survey.setId(UUID.randomUUID());
-        survey.setName("Test survey");
-        when(surveyRepository.findById(any(UUID.class))).thenReturn(Optional.of(survey));
+    // Then
+    verify(userIdentity)
+        .checkGlobalUserPermission(anyString(), eq(UserGroupAuthorisedActivityType.LIST_SURVEYS));
+  }
 
-        // When
-        // Then
-        mockMvc
-                .perform(
-                        get(String.format("/api/surveys/%s", survey.getId().toString()))
-                                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(handler().handlerType(SurveyEndpoint.class))
-                .andExpect(handler().methodName("getSurvey"))
-                .andExpect(jsonPath("id", is(survey.getId().toString())))
-                .andExpect(jsonPath("name", is("Test survey")));
-    }
+  @Test
+  public void testGetSurvey() throws Exception {
+    // Given
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+    survey.setName("Test survey");
+    when(surveyRepository.findById(any(UUID.class))).thenReturn(Optional.of(survey));
 
-    @Test
-    public void testCreateSurvey() throws Exception {
-        // Given
-        SurveyDto survey = new SurveyDto();
-        survey.setName("Test survey");
-        survey.setSurveyType(SurveyType.SOCIAL);
+    // When
+    // Then
+    mockMvc
+        .perform(
+            get(String.format("/api/surveys/%s", survey.getId().toString()))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(handler().handlerType(SurveyEndpoint.class))
+        .andExpect(handler().methodName("getSurvey"))
+        .andExpect(jsonPath("id", is(survey.getId().toString())))
+        .andExpect(jsonPath("name", is("Test survey")));
+  }
 
-        // When
-        mockMvc
-                .perform(
-                        post("/api/surveys", survey)
-                                .content(asJsonString(survey))
-                                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andExpect(handler().handlerType(SurveyEndpoint.class))
-                .andExpect(handler().methodName("createSurvey"));
+  @Test
+  public void testCreateSurvey() throws Exception {
+    // Given
+    SurveyDto survey = new SurveyDto();
+    survey.setName("Test survey");
+    survey.setSurveyType(SurveyType.SOCIAL);
 
-        // Then
-        ArgumentCaptor<Survey> surveyArgumentCaptor = ArgumentCaptor.forClass(Survey.class);
-        verify(surveyRepository).saveAndFlush(surveyArgumentCaptor.capture());
-        assertThat(surveyArgumentCaptor.getValue().getName()).isEqualTo("Test survey");
-        assertThat(surveyArgumentCaptor.getValue().getSampleValidationRules()
-    }
+    when(sampleDefinitionClient.getSampleDefinitionUrlForSurveyType(SurveyType.SOCIAL))
+        .thenReturn("test_url");
+    when(sampleDefinitionClient.getColumnValidatorsForSurveyType(SurveyType.SOCIAL))
+        .thenReturn(new ColumnValidator[0]);
 
-//    private ColumnValidator[] getColumnValidatorsFromUrl(String sampleDefintionUrll) {
-//        try {
-//            URL url = new URL(sampleDefintionUrll);
-//            return  OBJECT_MAPPER.readValue(url, ColumnValidator[].class);
-//        } catch (Exception e){
-//            log.error(String.format("Failed to successfully get ColumnValidator[] from %s.  Message: %s",
-//                    sampleDefintionUrll));
-//            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot get Sample Definition");
-//        }
-//    }
+    // When
+    mockMvc
+        .perform(
+            post("/api/surveys", survey)
+                .content(asJsonString(survey))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(handler().handlerType(SurveyEndpoint.class))
+        .andExpect(handler().methodName("createSurvey"));
 
-    @Test
-    public void testGetSurveyTypes() throws Exception {
-        mockMvc.perform(
-                        get(String.format("/api/surveys/surveyTypes"))
-                                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(handler().handlerType(SurveyEndpoint.class))
-                .andExpect(handler().methodName("getSurveyTypes"))
-                .andExpect(
-                        result ->
-                                assertThat(result.getResponse().getContentAsString())
-                                        .isEqualTo(
-                                                "[\"SOCIAL\",\"BUSINESS\",\"HEALTH\"]"));
-    }
+    // Then
+    ArgumentCaptor<Survey> surveyArgumentCaptor = ArgumentCaptor.forClass(Survey.class);
+    verify(surveyRepository).saveAndFlush(surveyArgumentCaptor.capture());
+    assertThat(surveyArgumentCaptor.getValue().getName()).isEqualTo("Test survey");
+  }
+
+  @Test
+  public void testGetSurveyTypes() throws Exception {
+    mockMvc
+        .perform(get(String.format("/api/surveys/surveyTypes")).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(handler().handlerType(SurveyEndpoint.class))
+        .andExpect(handler().methodName("getSurveyTypes"))
+        .andExpect(
+            result ->
+                assertThat(result.getResponse().getContentAsString())
+                    .isEqualTo("[\"SOCIAL\",\"BUSINESS\",\"HEALTH\"]"));
+  }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,3 +3,7 @@ spring:
     url: jdbc:postgresql://localhost:16436/postgres
 
 dummyuseridentity: test@test.com
+
+
+sampledefinitions:
+  social: file:src/test/resources/sampleDefinitionFiles/social_test.json

--- a/src/test/resources/sampleDefinitionFiles/social_test.json
+++ b/src/test/resources/sampleDefinitionFiles/social_test.json
@@ -1,0 +1,26 @@
+[
+  {
+    "columnName": "questionnaire",
+    "rules": [
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.MandatoryRule"
+      },
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.LengthRule",
+        "maxLength": 3
+      }
+    ]
+  },
+  {
+    "columnName": "sampleUnitRef",
+    "rules": [
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.MandatoryRule"
+      },
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.LengthRule",
+        "maxLength": 5
+      }
+    ]
+  }
+]

--- a/ui/src/CreateSurvey.js
+++ b/ui/src/CreateSurvey.js
@@ -1,18 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
-import Announcer from "react-a11y-announcer";
 import { Helmet } from "react-helmet";
 
 function CreateSurvey() {
-  let surveyNameInput = null;
-  const [surveyTypeOptions, setsurveyTypeOptions] =
-    useState([]);
+  const surveyNameInput = useRef(null);
+  const [surveyTypeOptions, setsurveyTypeOptions] = useState([]);
   const [surveyName, setSurveyName] = useState("");
   const [surveyType, setSurveyType] = useState("");
   const surveyTypeInput = useRef(null);
-  // const [hasErrors, setHasErrors] = useState(false);
-  // const [errorSummary, setErrorSummary] = useState([]);
-  // const [panelErrorsSummary, setPanelErrorsSummary] = useState([]);
+
+  let history = useHistory();
 
   useEffect(() => {
     async function fetchSurveyTypes() {
@@ -48,57 +45,22 @@ function CreateSurvey() {
     }
 
     fetchSurveyTypes();
-    surveyNameInput.focus();
-  });
-
+    surveyNameInput.current.focus();
+  }, []);
 
   function handleSurveyNameChange(event) {
     setSurveyName(event.target.value);
-    // setHasErrors(false);
   }
 
   function handlesurveyTypeChange(event) {
     setSurveyType(event.target.value);
-    // setHasErrors(false);
   }
 
-  let history = useHistory();
-
   async function createSurvey(event) {
-    // TODO: double click protection
-    // setHasErrors(false);
-    // setErrorSummary([]);
-    // setPanelErrorsSummary([]);
-
-    // let formSummaryErrors = validateCreateSurveyForm();
-
-    // if (formSummaryErrors.length === 0) {
-    //   formSummaryErrors = await createExportFileTemplateThroughAPI();
-    // }
-
-    // const errors = formSummaryErrors.map((formError, index) => (
-    //   <li key={index} className="list__item">
-    //     <Announcer text={formError.message} />
-    //     <a
-    //       className="list__link js-inpagelink"
-    //       // MUST use href in-page links for accessibility
-    //       href={`#${formError.anchorTo}`}
-    //     >
-    //       {formError.message}
-    //     </a>
-    //   </li>
-    // ));
-    // setErrorSummary(errors);
-
-    // if (formSummaryErrors.length) {
-    //   setHasErrors(true);
-    //   return;
-    // }
-
     event.preventDefault();
     const newSurvey = {
       name: surveyName,
-      surveyType: surveyType
+      surveyType: surveyType,
     };
 
     const response = await fetch("/api/surveys", {
@@ -111,100 +73,6 @@ function CreateSurvey() {
       history.push(`/surveys?flashMessageUntil=${Date.now() + 5000}`);
     }
   }
-
-  function getCreateSurveyErrors() {
-    let errors = [];
-
-    if (surveyName.trim().length === 0) {
-      errors.push({
-        message: "Survey Name cannot be empty",
-        anchorTo: surveyNameInput.current.id,
-      });
-    }
-
-    if (surveyName.trim() !== surveyName) {
-      errors.push({
-        message: "Survey Name should not have spaces at beginning or end",
-        anchorTo: surveyNameInput.current.id,
-      });
-    }
-
-    // TODO: Check it's unique compared to all the other surveys, will pass them in
-
-    return errors;
-  }
-
-  // TODO: Move this to a utils file?
-  function makePanelErrors(errorMessages) {
-    const errorPanels = errorMessages.map((error, index) => (
-      <p id={`error${index}`} key={index} className="panel__error">
-        <strong>{error.message}</strong>
-      </p>
-    ));
-
-    return errorPanels;
-  }
-
-  // function validateCreateSurveyForm() {
-  //   const createSurveyErrors = getCreateSurveyErrors();
-
-  //   setPanelErrorsSummary(makePanelErrors(createSurveyErrors));
-
-  //   return createSurveyErrors;
-  // }
-
-  // const surveyTypeFragment = (
-  //   <div className="question u-mt-no">
-  //     <fieldset
-  //       id="exportFileDestinationInput"
-  //       aria-required="true"
-  //       aria-label={"Select Survey Type"}
-  //       className="fieldset"
-  //       ref={surveyTypeInput}
-  //       onChange={handlesurveyTypeChange}
-  //     >
-  //       <legend className="fieldset__legend">
-  //         <label className="label venus">Select Survey Type</label>
-  //       </legend>
-  //       <div className="input-items">
-  //         <div className="radios__items">{surveyTypeOptions}</div>
-  //       </div>
-  //     </fieldset>
-  //   </div>
-  // );
-
-  // const surveyTypeInputErrorFragment = (
-  //   <div
-  //     className="panel panel--error panel--no-title u-mb-s"
-  //     id="SupplierInputError"
-  //   >
-  //     <span className="u-vh">Error: </span>
-  //     <div className="panel__body">
-  //       <p className="panel__error">
-  //         <strong>{supplierInputErrorSummary}</strong>
-  //       </p>
-  //       <div className="field">
-  //         <label className="label" htmlFor={exportFileDestinationInput}>
-  //           Select export file destination
-  //         </label>
-  //         <fieldset
-  //           id="exportFileDestinationInput"
-  //           aria-required="true"
-  //           aria-label={"Select export file destination"}
-  //           className="fieldset"
-  //           ref={exportFileDestinationInput}
-  //           onChange={handleExportFileDestinationChange}
-  //         >
-  //           <div className="input-items">
-  //             <div className="radios__items">
-  //               {exportFileDestinationOptions}
-  //             </div>
-  //           </div>
-  //         </fieldset>
-  //       </div>
-  //     </div>
-  //   </div>
-  // );
 
   return (
     <>
@@ -223,17 +91,16 @@ function CreateSurvey() {
             required
             value={surveyName}
             onChange={handleSurveyNameChange}
-            ref={(input) => {
-              surveyNameInput = input;
-            }}
+            ref={surveyNameInput}
           />
         </div>
         <br />
         <div className="question u-mt-no">
           <fieldset
-            id="exportFileDestinationInput"
+            id="surveyTypeInput"
             aria-required="true"
             aria-label={"Select Survey Type"}
+            required
             className="fieldset"
             ref={surveyTypeInput}
             onChange={handlesurveyTypeChange}

--- a/ui/src/CreateSurvey.js
+++ b/ui/src/CreateSurvey.js
@@ -1,26 +1,104 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
+import Announcer from "react-a11y-announcer";
 import { Helmet } from "react-helmet";
 
 function CreateSurvey() {
   let surveyNameInput = null;
+  const [surveyTypeOptions, setsurveyTypeOptions] =
+    useState([]);
+  const [surveyName, setSurveyName] = useState("");
+  const [surveyType, setSurveyType] = useState("");
+  const surveyTypeInput = useRef(null);
+  // const [hasErrors, setHasErrors] = useState(false);
+  // const [errorSummary, setErrorSummary] = useState([]);
+  // const [panelErrorsSummary, setPanelErrorsSummary] = useState([]);
 
   useEffect(() => {
+    async function fetchSurveyTypes() {
+      const response = await fetch("/api/surveys/surveyTypes");
+
+      const surveyTypes = await response.json();
+
+      const options = surveyTypes.map((surveyType, index) => (
+        <div key={index}>
+          <p className="radios__item">
+            <span className="radio">
+              <input
+                id={surveyType}
+                type="radio"
+                className="radio__input js-radio"
+                value={surveyType}
+                name="surveyType"
+                required
+              />
+              <label
+                htmlFor={surveyType}
+                id={`${surveyType}-label`}
+                className="radio__label"
+              >
+                {surveyType}
+              </label>
+            </span>
+          </p>
+          <br />
+        </div>
+      ));
+      setsurveyTypeOptions(options);
+    }
+
+    fetchSurveyTypes();
     surveyNameInput.focus();
   });
 
-  const [surveyName, setSurveyName] = useState("");
 
   function handleSurveyNameChange(event) {
     setSurveyName(event.target.value);
+    // setHasErrors(false);
+  }
+
+  function handlesurveyTypeChange(event) {
+    setSurveyType(event.target.value);
+    // setHasErrors(false);
   }
 
   let history = useHistory();
 
   async function createSurvey(event) {
+    // TODO: double click protection
+    // setHasErrors(false);
+    // setErrorSummary([]);
+    // setPanelErrorsSummary([]);
+
+    // let formSummaryErrors = validateCreateSurveyForm();
+
+    // if (formSummaryErrors.length === 0) {
+    //   formSummaryErrors = await createExportFileTemplateThroughAPI();
+    // }
+
+    // const errors = formSummaryErrors.map((formError, index) => (
+    //   <li key={index} className="list__item">
+    //     <Announcer text={formError.message} />
+    //     <a
+    //       className="list__link js-inpagelink"
+    //       // MUST use href in-page links for accessibility
+    //       href={`#${formError.anchorTo}`}
+    //     >
+    //       {formError.message}
+    //     </a>
+    //   </li>
+    // ));
+    // setErrorSummary(errors);
+
+    // if (formSummaryErrors.length) {
+    //   setHasErrors(true);
+    //   return;
+    // }
+
     event.preventDefault();
     const newSurvey = {
       name: surveyName,
+      surveyType: surveyType
     };
 
     const response = await fetch("/api/surveys", {
@@ -33,6 +111,100 @@ function CreateSurvey() {
       history.push(`/surveys?flashMessageUntil=${Date.now() + 5000}`);
     }
   }
+
+  function getCreateSurveyErrors() {
+    let errors = [];
+
+    if (surveyName.trim().length === 0) {
+      errors.push({
+        message: "Survey Name cannot be empty",
+        anchorTo: surveyNameInput.current.id,
+      });
+    }
+
+    if (surveyName.trim() !== surveyName) {
+      errors.push({
+        message: "Survey Name should not have spaces at beginning or end",
+        anchorTo: surveyNameInput.current.id,
+      });
+    }
+
+    // TODO: Check it's unique compared to all the other surveys, will pass them in
+
+    return errors;
+  }
+
+  // TODO: Move this to a utils file?
+  function makePanelErrors(errorMessages) {
+    const errorPanels = errorMessages.map((error, index) => (
+      <p id={`error${index}`} key={index} className="panel__error">
+        <strong>{error.message}</strong>
+      </p>
+    ));
+
+    return errorPanels;
+  }
+
+  // function validateCreateSurveyForm() {
+  //   const createSurveyErrors = getCreateSurveyErrors();
+
+  //   setPanelErrorsSummary(makePanelErrors(createSurveyErrors));
+
+  //   return createSurveyErrors;
+  // }
+
+  // const surveyTypeFragment = (
+  //   <div className="question u-mt-no">
+  //     <fieldset
+  //       id="exportFileDestinationInput"
+  //       aria-required="true"
+  //       aria-label={"Select Survey Type"}
+  //       className="fieldset"
+  //       ref={surveyTypeInput}
+  //       onChange={handlesurveyTypeChange}
+  //     >
+  //       <legend className="fieldset__legend">
+  //         <label className="label venus">Select Survey Type</label>
+  //       </legend>
+  //       <div className="input-items">
+  //         <div className="radios__items">{surveyTypeOptions}</div>
+  //       </div>
+  //     </fieldset>
+  //   </div>
+  // );
+
+  // const surveyTypeInputErrorFragment = (
+  //   <div
+  //     className="panel panel--error panel--no-title u-mb-s"
+  //     id="SupplierInputError"
+  //   >
+  //     <span className="u-vh">Error: </span>
+  //     <div className="panel__body">
+  //       <p className="panel__error">
+  //         <strong>{supplierInputErrorSummary}</strong>
+  //       </p>
+  //       <div className="field">
+  //         <label className="label" htmlFor={exportFileDestinationInput}>
+  //           Select export file destination
+  //         </label>
+  //         <fieldset
+  //           id="exportFileDestinationInput"
+  //           aria-required="true"
+  //           aria-label={"Select export file destination"}
+  //           className="fieldset"
+  //           ref={exportFileDestinationInput}
+  //           onChange={handleExportFileDestinationChange}
+  //         >
+  //           <div className="input-items">
+  //             <div className="radios__items">
+  //               {exportFileDestinationOptions}
+  //             </div>
+  //           </div>
+  //         </fieldset>
+  //       </div>
+  //     </div>
+  //   </div>
+  // );
 
   return (
     <>
@@ -56,7 +228,24 @@ function CreateSurvey() {
             }}
           />
         </div>
-
+        <br />
+        <div className="question u-mt-no">
+          <fieldset
+            id="exportFileDestinationInput"
+            aria-required="true"
+            aria-label={"Select Survey Type"}
+            className="fieldset"
+            ref={surveyTypeInput}
+            onChange={handlesurveyTypeChange}
+          >
+            <legend className="fieldset__legend">
+              <label className="label venus">Select Survey Type</label>
+            </legend>
+            <div className="input-items">
+              <div className="radios__items">{surveyTypeOptions}</div>
+            </div>
+          </fieldset>
+        </div>
         <p></p>
         <button type="submit" className="btn btn--link">
           <span className="btn__inner">Create Survey</span>


### PR DESCRIPTION
# Motivation and Context
Cutting and pasting huge chunks of json validation rules is both messy and uncontrolled.
Instead the validation rules already exist in github, get them from there.

# What has changed
Added in survey Type

# How to test?
mvn clean install
Then run it and in the front end you should be able/forced to create a survey with a survey type.  Check the DB, do the rules look sensible


# Links
[<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->](https://trello.com/b/yarvSxGu/social-generic-response-management)

# Screenshots (if appropriate):
