### PR TITLE
Collection Instrument Rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.6.0-SNAPSHOT</version>
+      <version>4.7.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>


### PR DESCRIPTION
# Motivation and Context
Choosing the correct collection instrument (CI) for a respondent needs to be rules-based, because there are myriad known and unknown requirements that the ONS has, regarding which questionnaire the organisation wants a respondent to fill in.

# What has changed
Allowed a block of rules for choosing a collection instrument to be stored against a collection exercise, and these rules are then used to choose the right CI at the moment when the action rule runs.

This has been performance tested with 10k cases, which took 3 minutes to produce the print file = 55/second... pretty slow. but this was on my local MacBook running with the Pub/Sub emulator, and in debug mode. It should scale horizontally, and besides, we need to know what the performance was before for a like-for-like comparison.

We could try choosing the CI when we load the sample, like RAS-RM does, but that just moves the problem around, and it's far less elegant because the CI is not then changing dynamically as the case moves between waves.

I think it's unavoidable that this is a CPU intensive operation, and we simply need to beef up the amount of CPU we give to the Case Processor to accommodate the demand, for massive surveys. At Census scale we would run 10 or more Case Processors.

# How to test?
Set up a survey, then when setting up a collection exercise use these collection instrument rules (or similar):
```json
[
  {
    "priority": 1000,
    "spelExpression": "caze.sample['POSTCODE'] == 'abc123' and uacMetadata != null and uacMetadata['wave'] == 1",
    "collectionInstrumentUrl": "http://quiteAspecific/survey"
  },
  {
    "priority": 500,
    "spelExpression": "caze.sample['POSTCODE'] == 'xyz999'",
    "collectionInstrumentUrl": "http://slightlyLessSpecific/survey"
  },
  {
    "priority": 0,
    "spelExpression": null,
    "collectionInstrumentUrl": "http://allPurpose/survey"
  }
]
```

Then, set up an action rule which includes a UAC (e.g. `["__uac__"]`).

When the action rule triggers, you should be able to see the CI in the emitted `uacUpdate` events, and in the database.

# Links
Trello: https://trello.com/c/SDRjFfs3