### PR TITLE
Upgrade to Java 17 and Spring Boot 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 jobs:
   include:
     - language: java
-      jdk: openjdk11
+      jdk: openjdk17
 
       before_install:
         - make format-check-mvn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:11-slim
-CMD ["/usr/local/openjdk-11/bin/java", "-jar", "/opt/ssdc-rm-response-operations.jar"]
+FROM openjdk:17-slim
+CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-response-operations.jar"]
 
 RUN groupadd --gid 999 response-operations && \
     useradd --create-home --system --uid 999 --gid response-operations response-operations

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.9.0-SNAPSHOT</version>
+      <version>4.10.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,13 +11,13 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.2</version>
+    <version>2.6.0</version>
   </parent>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <repositories>
@@ -57,12 +57,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.micrometer</groupId>
-          <artifactId>micrometer-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -86,13 +80,8 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-      <version>1.5.1</version>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-stackdriver</artifactId>
-      <version>1.5.1</version>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
@@ -252,7 +241,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.3</version>
+        <version>0.8.7</version>
         <executions>
           <execution>
             <goals>
@@ -271,8 +260,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.11</source>
-          <target>1.11</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,7 @@ management:
       enabled: true
   metrics:
     tags:
-      application: Support Tool
+      application: Response Operations
       pod: ${HOSTNAME}
     export:
       stackdriver:

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -32,15 +32,7 @@
           <div class="header__top" role="banner">
             <div class="container container--wide">
               <div
-                class="
-                  header__grid-top
-                  grid
-                  grid--gutterless
-                  grid--flex
-                  grid--between
-                  grid--vertical-center
-                  grid--no-wrap
-                "
+                class="header__grid-top grid grid--gutterless grid--flex grid--between grid--vertical-center grid--no-wrap"
               >
                 <div class="grid__col col-auto">
                   <div class="logo">
@@ -57,14 +49,7 @@
           <div class="header__main">
             <div class="container container--wide">
               <div
-                class="
-                  grid
-                  grid--gutterless
-                  grid--flex
-                  grid--between
-                  grid--vertical-center
-                  grid--no-wrap
-                "
+                class="grid grid--gutterless grid--flex grid--between grid--vertical-center grid--no-wrap"
               >
                 <div class="grid__col col-auto u-flex-shrink">
                   <h1 class="header__title">Response Management Operations</h1>
@@ -75,10 +60,7 @@
           <div class="header__nav">
             <div class="container">
               <nav
-                class="
-                  nav nav--horizontal nav--light nav--main nav--h-m
-                  js-main-nav
-                "
+                class="nav nav--horizontal nav--light nav--main nav--h-m js-main-nav"
                 aria-label="Main menu"
                 aria-hidden="true"
                 id="main-nav"


### PR DESCRIPTION
# Motivation and Context
Java 11 is no longer the LTS (Long-Term Support) version. Java 17 is the LTS version, so we should use that.

Spring Boot 2.6.0 is the first version of Spring Boot to support Java 17, so we should use that too.

# What has changed
Upgraded to Java 17 and Spring Boot 2.6.0, plus upped any other versions required for everything to work.

Switched the Docker base image over to be JDK 17 too.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/kcJGECdH