### PR TITLE
Bump log4j to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <repositories>
@@ -50,12 +50,12 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.12.2-SNAPSHOT</version>
+      <version>4.12.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.4.2-SNAPSHOT</version>
+      <version>1.4.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Motivation and Context
Another vulnerability in log4j means another version update.

# What has changed
Updated the version of log4j and the versions of common-entity-model and shared-sample-validation

# How to test?
Build the branches of shared-sample-validation and common-entity-model then build this one and check that it builds ok.

# Links
https://trello.com/c/olugyyoI
https://github.com/ONSdigital/ssdc-shared-sample-validation/pull/11
https://github.com/ONSdigital/ssdc-rm-ddl/pull/80