### PR TITLE
3196 - Enable dummy user handling

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpoint.java
@@ -2,12 +2,15 @@ package uk.gov.ons.ssdc.responseoperations.endpoint;
 
 import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.SUPER_USER;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -24,10 +27,23 @@ import uk.gov.ons.ssdc.responseoperations.model.repository.UserRepository;
 @RestController
 @RequestMapping(value = "/api/auth")
 public class AuthorisationEndpoint {
-  private final UserRepository userRepository;
+  private static final Logger log = LoggerFactory.getLogger(AuthorisationEndpoint.class);
 
-  public AuthorisationEndpoint(UserRepository userRepository) {
+  private final UserRepository userRepository;
+  private final boolean dummyUserIdentityAllowed;
+  private final String dummySuperUserIdentity;
+
+  public AuthorisationEndpoint(
+      UserRepository userRepository,
+      @Value("${dummyuseridentity-allowed}") boolean dummyUserIdentityAllowed,
+      @Value("${dummysuperuseridentity}") String dummySuperUserIdentity) {
     this.userRepository = userRepository;
+    this.dummyUserIdentityAllowed = dummyUserIdentityAllowed;
+    this.dummySuperUserIdentity = dummySuperUserIdentity;
+
+    if (dummyUserIdentityAllowed) {
+      log.error("*** SECURITY ALERT *** IF YOU SEE THIS IN PRODUCTION, SHUT DOWN IMMEDIATELY!!!");
+    }
   }
 
   @GetMapping
@@ -35,8 +51,9 @@ public class AuthorisationEndpoint {
       @RequestParam(required = false, value = "surveyId") Optional<UUID> surveyId,
       @RequestAttribute("userEmail") String userEmail) {
 
-    // TODO: Remove this before releasing to production!
-    if (userEmail.equals("dummy@fake-email.com")) {
+    if (dummyUserIdentityAllowed && userEmail.equals(dummySuperUserIdentity)) {
+      // Dummy test super user is fully authorised, bypassing all security
+      // This is **STRICTLY** for ease of dev/testing in non-production environments
       return Set.of(UserGroupAuthorisedActivityType.values());
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentity.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ssdc.responseoperations.security;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.auth.oauth2.TokenVerifier;
 import java.util.Optional;
@@ -17,28 +19,40 @@ import uk.gov.ons.ssdc.responseoperations.model.repository.UserRepository;
 
 @Component
 public class UserIdentity {
+  private static final Logger log = LoggerFactory.getLogger(UserIdentity.class);
   private static final String IAP_ISSUER_URL = "https://cloud.google.com/iap";
 
   private final UserRepository userRepository;
   private final String iapAudience;
   private final String dummyUserIdentity;
+  private final boolean dummyUserIdentityAllowed;
+  private final String dummySuperUserIdentity;
 
   private TokenVerifier tokenVerifier = null;
 
   public UserIdentity(
       UserRepository userRepository,
       @Value("${iapaudience}") String iapAudience,
-      @Value("${dummyuseridentity}") String dummyUserIdentity) {
+      @Value("${dummyuseridentity}") String dummyUserIdentity,
+      @Value("${dummyuseridentity-allowed}") boolean dummyUserIdentityAllowed,
+      @Value("${dummysuperuseridentity}") String dummySuperUserIdentity) {
     this.userRepository = userRepository;
     this.iapAudience = iapAudience;
     this.dummyUserIdentity = dummyUserIdentity;
+    this.dummyUserIdentityAllowed = dummyUserIdentityAllowed;
+    this.dummySuperUserIdentity = dummySuperUserIdentity;
+
+    if (dummyUserIdentityAllowed) {
+      log.error("*** SECURITY ALERT *** IF YOU SEE THIS IN PRODUCTION, SHUT DOWN IMMEDIATELY!!!");
+    }
   }
 
   public void checkUserPermission(
       String userEmail, Survey survey, UserGroupAuthorisedActivityType activity) {
-    // TODO: Remove this before releasing to production!
-    if (userEmail.equals("dummy@fake-email.com")) {
-      return; // User is authorised - hack workaround for ease of dev/testing... remember to remove!
+    if (dummyUserIdentityAllowed && userEmail.equals(dummySuperUserIdentity)) {
+      // Dummy test super user is fully authorised, bypassing all security
+      // This is **STRICTLY** for ease of dev/testing in non-production environments
+      return;
     }
 
     Optional<User> userOpt = userRepository.findByEmail(userEmail);
@@ -76,9 +90,10 @@ public class UserIdentity {
   public void checkGlobalUserPermission(
       String userEmail, UserGroupAuthorisedActivityType activity) {
 
-    // TODO: Remove this before releasing to production!
-    if (userEmail.equals("dummy@fake-email.com")) {
-      return; // User is authorised - hack workaround for ease of dev/testing... remember to remove!
+    if (dummyUserIdentityAllowed && userEmail.equals(dummySuperUserIdentity)) {
+      // Dummy test super user is fully authorised, bypassing all security
+      // This is **STRICTLY** for ease of dev/testing in non-production environments
+      return;
     }
 
     Optional<User> userOpt = userRepository.findByEmail(userEmail);
@@ -107,11 +122,14 @@ public class UserIdentity {
   }
 
   public String getUserEmail(String jwtToken) {
-    if (!StringUtils.hasText(jwtToken)) {
-      // This should throw an exception if we're running in GCP
-      // We are faking the email address so that we can test locally
-      // TODO: remove this before releasing to production!
+    if (dummyUserIdentityAllowed && !StringUtils.hasText(jwtToken)) {
+      // If there's no JWT header and dummy test user is enabled, use it
+      // This is **STRICTLY** for ease of dev/testing in non-production environments
       return dummyUserIdentity;
+    } else if (!StringUtils.hasText(jwtToken)) {
+      // This request must have come from __inside__ the firewall/cluster, and should not be allowed
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, String.format("Requests bypassing IAP are strictly forbidden"));
     } else {
       return verifyJwtAndGetEmail(jwtToken);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,8 +71,9 @@ sampledefinitions:
   health: https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/sis/0.1.0-DRAFT/sis.json
 
 
-# TODO: Remove this before releasing to prod
+dummyuseridentity-allowed: false # This ** MUST ALWAYS!! ** be false in production!!!
 dummyuseridentity: dummy@fake-email.com
+dummysuperuseridentity: dummy@fake-email.com
 
 exportfiledestinationconfigfile: dummy-export-file-destination-config.json
 

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpointTest.java
@@ -10,9 +10,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -30,7 +30,15 @@ public class AuthorisationEndpointTest {
 
   @Mock private UserRepository userRepository;
 
-  @InjectMocks private AuthorisationEndpoint underTest;
+  private AuthorisationEndpoint underTest;
+
+  @BeforeEach
+  public void setUp() {
+    boolean dummyUserIdentityAllowed = false;
+    underTest =
+        new AuthorisationEndpoint(
+            userRepository, dummyUserIdentityAllowed, "testDummySuperUserIdentity");
+  }
 
   @Test
   public void testSingleGlobalPermission() {

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentityTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentityTest.java
@@ -8,9 +8,9 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -27,7 +27,19 @@ import uk.gov.ons.ssdc.responseoperations.model.repository.UserRepository;
 class UserIdentityTest {
   @Mock private UserRepository userRepository;
 
-  @InjectMocks private UserIdentity underTest;
+  private UserIdentity underTest;
+
+  @BeforeEach
+  public void setUp() {
+    boolean dummyUserIdentityAllowed = false;
+    underTest =
+        new UserIdentity(
+            userRepository,
+            "testIapAudience",
+            "testDummyUserIdentity",
+            dummyUserIdentityAllowed,
+            "testDummySuperUserIdentity");
+  }
 
   @Test
   public void testSingleGlobalPermission() {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,7 +3,7 @@ spring:
     url: jdbc:postgresql://localhost:16436/postgres
 
 dummyuseridentity: test@test.com
-
+dummyuseridentity-allowed: true # This ** MUST ALWAYS!! ** be false in production!!!
 
 sampledefinitions:
   social: file:src/test/resources/sampleDefinitionFiles/social_test.json


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We should make use of the same safeguards in the Support Tool which prevent the dummy user account from being used maliciously in production.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Made use of Support Tool safeguards

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
See 'How to test' from [this PR](https://github.com/ONSdigital/ssdc-rm-support-tool/pull/129), and change support tool to response-operations

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/e4BUguca/3196-rops-should-have-production-quality-dummy-user-handling-the-same-as-support-tool-5