### PR TITLE
3288 - Prevent duplicate print template items in UI & backend

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/ExportFileTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/ExportFileTemplateEndpoint.java
@@ -1,7 +1,10 @@
 package uk.gov.ons.ssdc.responseoperations.endpoint;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
 import org.springframework.http.HttpStatus;
@@ -109,6 +112,11 @@ public class ExportFileTemplateEndpoint {
       if (StringUtils.isBlank(column)) {
         return Optional.of("Template cannot have empty columns");
       }
+    }
+
+    Set<String> templateSet = new HashSet<>(Arrays.asList(template));
+    if (templateSet.size() != template.length) {
+      return Optional.of("Template cannot have duplicate columns");
     }
 
     return Optional.empty();

--- a/ui/src/CreateExportFileTemplate.js
+++ b/ui/src/CreateExportFileTemplate.js
@@ -87,7 +87,7 @@ function CreateExportFileTemplate() {
   function getExportFileTemplateInputErrors() {
     const exportFileTemplateInputErrorInfo = {
       arrayFormatError:
-        "Export file template must be JSON array, with one or more unique elements",
+        "Export file template must be JSON array with one or more unique elements",
       jsonFormatError: "Export file template is not valid JSON",
     };
 

--- a/ui/src/CreateExportFileTemplate.js
+++ b/ui/src/CreateExportFileTemplate.js
@@ -94,8 +94,8 @@ function CreateExportFileTemplate() {
     let errors = [];
     try {
       const parsedJson = JSON.parse(exportFileTemplate);
-      const hasDuplicateTemplateItems = new Set(parsedJson).size !== parsedJson.length
-      if (!Array.isArray(parsedJson) || parsedJson.length === 0 || hasDuplicateTemplateItems) {
+      const hasDuplicateTemplateColumns = new Set(parsedJson).size !== parsedJson.length
+      if (!Array.isArray(parsedJson) || parsedJson.length === 0 || hasDuplicateTemplateColumns) {
         errors.push({
           message: exportFileTemplateInputErrorInfo.arrayFormatError,
           anchorTo: exportFileTemplateInput.current.id,

--- a/ui/src/CreateExportFileTemplate.js
+++ b/ui/src/CreateExportFileTemplate.js
@@ -94,8 +94,13 @@ function CreateExportFileTemplate() {
     let errors = [];
     try {
       const parsedJson = JSON.parse(exportFileTemplate);
-      const hasDuplicateTemplateColumns = new Set(parsedJson).size !== parsedJson.length
-      if (!Array.isArray(parsedJson) || parsedJson.length === 0 || hasDuplicateTemplateColumns) {
+      const hasDuplicateTemplateColumns =
+        new Set(parsedJson).size !== parsedJson.length;
+      if (
+        !Array.isArray(parsedJson) ||
+        parsedJson.length === 0 ||
+        hasDuplicateTemplateColumns
+      ) {
         errors.push({
           message: exportFileTemplateInputErrorInfo.arrayFormatError,
           anchorTo: exportFileTemplateInput.current.id,

--- a/ui/src/CreateExportFileTemplate.js
+++ b/ui/src/CreateExportFileTemplate.js
@@ -87,14 +87,15 @@ function CreateExportFileTemplate() {
   function getExportFileTemplateInputErrors() {
     const exportFileTemplateInputErrorInfo = {
       arrayFormatError:
-        "Export file template must be JSON array with one or more elements",
+        "Export file template must be JSON array, with one or more unique elements",
       jsonFormatError: "Export file template is not valid JSON",
     };
 
     let errors = [];
     try {
       const parsedJson = JSON.parse(exportFileTemplate);
-      if (!Array.isArray(parsedJson) || parsedJson.length === 0) {
+      const hasDuplicateTemplateItems = new Set(parsedJson).size !== parsedJson.length
+      if (!Array.isArray(parsedJson) || parsedJson.length === 0 || hasDuplicateTemplateItems) {
         errors.push({
           message: exportFileTemplateInputErrorInfo.arrayFormatError,
           anchorTo: exportFileTemplateInput.current.id,


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to prevent users from being able to generate a print template that contains duplicate columns

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated front and back end with validation for duplicates 

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Should all still work as expected

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/K5hPmnRb/3288-print-fulfilment-template-gives-internal-server-error-when-trying-to-add-a-template-with-duplicate-attributes-to-a-survey-5