### PR TITLE
 case insensitive checking

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpoint.java
@@ -59,7 +59,7 @@ public class AuthorisationEndpoint {
 
     User user =
         userRepository
-            .findByEmail(userEmail)
+            .findByEmailIgnoreCase(userEmail)
             .orElseThrow(
                 () ->
                     new ResponseStatusException(

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpoint.java
@@ -51,7 +51,7 @@ public class AuthorisationEndpoint {
       @RequestParam(required = false, value = "surveyId") Optional<UUID> surveyId,
       @RequestAttribute("userEmail") String userEmail) {
 
-    if (dummyUserIdentityAllowed && userEmail.equals(dummySuperUserIdentity)) {
+    if (dummyUserIdentityAllowed && userEmail.equalsIgnoreCase(dummySuperUserIdentity)) {
       // Dummy test super user is fully authorised, bypassing all security
       // This is **STRICTLY** for ease of dev/testing in non-production environments
       return Set.of(UserGroupAuthorisedActivityType.values());

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/UserGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/UserGroupEndpoint.java
@@ -22,7 +22,7 @@ public class UserGroupEndpoint {
 
   @GetMapping("/thisUserAdminGroups")
   public List<UserGroupDto> getUserAdminGroups(@RequestAttribute("userEmail") String userEmail) {
-    return userGroupAdminRepository.findByUserEmail(userEmail).stream()
+    return userGroupAdminRepository.findByUserEmailIgnoreCase(userEmail).stream()
         .map(UserGroupAdmin::getGroup)
         .map(this::mapDto)
         .collect(Collectors.toList());

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/UserGroupMemberEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/endpoint/UserGroupMemberEndpoint.java
@@ -60,7 +60,7 @@ public class UserGroupMemberEndpoint {
                         HttpStatus.BAD_REQUEST, String.format("Group %s not found", groupId)));
 
     if (group.getAdmins().stream()
-        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equalsIgnoreCase(userEmail))) {
       throw new ResponseStatusException(
           HttpStatus.FORBIDDEN,
           String.format("User %s not an admin of %s", userEmail, group.getName()));
@@ -85,7 +85,7 @@ public class UserGroupMemberEndpoint {
                         String.format("Did not find groupMemberId %s", groupMemberId)));
 
     if (userGroupMember.getGroup().getAdmins().stream()
-        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equalsIgnoreCase(userEmail))) {
       throw new ResponseStatusException(
           HttpStatus.FORBIDDEN,
           String.format(
@@ -126,7 +126,7 @@ public class UserGroupMemberEndpoint {
                             userGroupMemberDto.getGroupId())));
 
     if (group.getAdmins().stream()
-        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equalsIgnoreCase(userEmail))) {
       // If you're not admin of this group, you have to be super user
       userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
     }

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/model/repository/UserGroupAdminRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/model/repository/UserGroupAdminRepository.java
@@ -6,9 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAdmin;
 
 public interface UserGroupAdminRepository extends JpaRepository<UserGroupAdmin, UUID> {
-  List<UserGroupAdmin> findByUserEmail(String email);
+  List<UserGroupAdmin> findByUserEmailIgnoreCase(String email);
 
   List<UserGroupAdmin> findByGroupId(UUID groupId);
-
-  boolean existsByUserEmail(String email);
 }

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/model/repository/UserRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/model/repository/UserRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.User;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-  Optional<User> findByEmail(String email);
+  Optional<User> findByEmailIgnoreCase(String email);
 }

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentity.java
@@ -56,7 +56,7 @@ public class UserIdentity {
 
     User user =
         userRepository
-            .findByEmail(userEmail)
+            .findByEmailIgnoreCase(userEmail)
             .orElseThrow(
                 () ->
                     new ResponseStatusException(
@@ -97,7 +97,7 @@ public class UserIdentity {
 
     User user =
         userRepository
-            .findByEmail(userEmail)
+            .findByEmailIgnoreCase(userEmail)
             .orElseThrow(
                 () ->
                     new ResponseStatusException(

--- a/src/main/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentity.java
@@ -48,7 +48,7 @@ public class UserIdentity {
 
   public void checkUserPermission(
       String userEmail, Survey survey, UserGroupAuthorisedActivityType activity) {
-    if (dummyUserIdentityAllowed && userEmail.equals(dummySuperUserIdentity)) {
+    if (dummyUserIdentityAllowed && userEmail.equalsIgnoreCase(dummySuperUserIdentity)) {
       // Dummy test super user is fully authorised, bypassing all security
       // This is **STRICTLY** for ease of dev/testing in non-production environments
       return;
@@ -89,7 +89,7 @@ public class UserIdentity {
   public void checkGlobalUserPermission(
       String userEmail, UserGroupAuthorisedActivityType activity) {
 
-    if (dummyUserIdentityAllowed && userEmail.equals(dummySuperUserIdentity)) {
+    if (dummyUserIdentityAllowed && userEmail.equalsIgnoreCase(dummySuperUserIdentity)) {
       // Dummy test super user is fully authorised, bypassing all security
       // This is **STRICTLY** for ease of dev/testing in non-production environments
       return;

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/AuthorisationEndpointTest.java
@@ -47,7 +47,7 @@ public class AuthorisationEndpointTest {
 
     User user = getUser(UserGroupAuthorisedActivityType.CREATE_SURVEY, null);
 
-    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmailIgnoreCase(anyString())).thenReturn(Optional.of(user));
 
     // First, check that user has permission when no survey is specified
     Set<UserGroupAuthorisedActivityType> authorisedActivities =
@@ -70,7 +70,7 @@ public class AuthorisationEndpointTest {
   public void testGetAuthActivitiesUserUnknownToRMException() {
     // When, then throws
 
-    when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+    when(userRepository.findByEmailIgnoreCase(anyString())).thenReturn(Optional.empty());
 
     RuntimeException thrown =
         assertThrows(
@@ -87,7 +87,7 @@ public class AuthorisationEndpointTest {
 
     User user = getUser(UserGroupAuthorisedActivityType.SUPER_USER, null);
 
-    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmailIgnoreCase(anyString())).thenReturn(Optional.of(user));
 
     // First, check that user has super user permissions when no survey is specified
     Set<UserGroupAuthorisedActivityType> authorisedActivities =
@@ -110,7 +110,7 @@ public class AuthorisationEndpointTest {
     survey.setId(UUID.randomUUID());
     User user = getUser(UserGroupAuthorisedActivityType.CREATE_COLLECTION_EXERCISE, survey);
 
-    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmailIgnoreCase(anyString())).thenReturn(Optional.of(user));
 
     // First, check that user has permission on the specific survey
     Set<UserGroupAuthorisedActivityType> authorisedActivities =
@@ -140,7 +140,7 @@ public class AuthorisationEndpointTest {
     survey.setId(UUID.randomUUID());
     User user = getUser(UserGroupAuthorisedActivityType.SUPER_USER, survey);
 
-    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmailIgnoreCase(anyString())).thenReturn(Optional.of(user));
 
     // First, check that the user has all permissions on the specific survey
     Set<UserGroupAuthorisedActivityType> authorisedActivities =

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/UserGroupEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/endpoint/UserGroupEndpointTest.java
@@ -46,7 +46,7 @@ class UserGroupEndpointTest {
     userGroupAdmin.setGroup(userGroup);
     List<UserGroupAdmin> userGroupList = List.of(userGroupAdmin);
 
-    when(userGroupAdminRepository.findByUserEmail(anyString())).thenReturn(userGroupList);
+    when(userGroupAdminRepository.findByUserEmailIgnoreCase(anyString())).thenReturn(userGroupList);
 
     mockMvc
         .perform(
@@ -59,6 +59,6 @@ class UserGroupEndpointTest {
         .andExpect(jsonPath("$[0].id", is(userGroup.getId().toString())))
         .andExpect(jsonPath("$[0].name", is(userGroup.getName())));
 
-    verify(userGroupAdminRepository).findByUserEmail("nice@email.com");
+    verify(userGroupAdminRepository).findByUserEmailIgnoreCase("nice@email.com");
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentityTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/responseoperations/security/UserIdentityTest.java
@@ -48,7 +48,7 @@ class UserIdentityTest {
 
     User user = getUser(UserGroupAuthorisedActivityType.CREATE_SURVEY, null);
 
-    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmailIgnoreCase(anyString())).thenReturn(Optional.of(user));
 
     // First check the allowed permission
     underTest.checkGlobalUserPermission(
@@ -74,7 +74,7 @@ class UserIdentityTest {
 
     User user = getUser(UserGroupAuthorisedActivityType.SUPER_USER, null);
 
-    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmailIgnoreCase(anyString())).thenReturn(Optional.of(user));
 
     for (UserGroupAuthorisedActivityType activityType : UserGroupAuthorisedActivityType.values()) {
       underTest.checkGlobalUserPermission("test@test.com", activityType);
@@ -87,7 +87,7 @@ class UserIdentityTest {
     survey.setId(UUID.randomUUID());
     User user = getUser(UserGroupAuthorisedActivityType.CREATE_COLLECTION_EXERCISE, survey);
 
-    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmailIgnoreCase(anyString())).thenReturn(Optional.of(user));
 
     // First, check that user has permission on the specific survey
     underTest.checkUserPermission(
@@ -110,7 +110,7 @@ class UserIdentityTest {
     survey.setId(UUID.randomUUID());
     User user = getUser(UserGroupAuthorisedActivityType.SUPER_USER, survey);
 
-    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmailIgnoreCase(anyString())).thenReturn(Optional.of(user));
 
     // First, check that the user has all permissions on the specific survey
     for (UserGroupAuthorisedActivityType activityType : UserGroupAuthorisedActivityType.values()) {

--- a/ui/src/AddUserToGroup.js
+++ b/ui/src/AddUserToGroup.js
@@ -80,16 +80,10 @@ function AddUserToGroup(props) {
   }
 
   function isEmailAlreadyInGroup(newEmail) {
-    if (
-      location.state.existingEmailsInGroup.filter(
+    return location.state.existingEmailsInGroup.filter(
         (existingEmail) =>
-          existingEmail.toLowerCase() === newEmail.toLowerCase()
-      ).length > 0
-    ) {
-      return true;
-    }
-
-    return false;
+            existingEmail.toLowerCase() === newEmail.toLowerCase()
+    ).length > 0;
   }
 
   async function addUserToGroup() {

--- a/ui/src/AddUserToGroup.js
+++ b/ui/src/AddUserToGroup.js
@@ -68,18 +68,24 @@ function AddUserToGroup(props) {
   // Or by cutting and pasting a valid email address.
   // Check it's in out list and get the UserId
   function checkEmailExistsAndGetUserId(userInput) {
-    var matchingUser = userList[0].users.filter((user) => user.email.toLowerCase() === userInput.toLowerCase())
+    var matchingUser = userList[0].users.filter(
+      (user) => user.email.toLowerCase() === userInput.toLowerCase()
+    );
 
     if (matchingUser.length === 0) {
       return undefined;
     }
 
-    return matchingUser[0].id
+    return matchingUser[0].id;
   }
 
   function isEmailAlreadyInGroup(newEmail) {
-
-    if (location.state.existingEmailsInGroup.filter((existingEmail) => existingEmail.toLowerCase() === newEmail.toLowerCase()).length > 0) {
+    if (
+      location.state.existingEmailsInGroup.filter(
+        (existingEmail) =>
+          existingEmail.toLowerCase() === newEmail.toLowerCase()
+      ).length > 0
+    ) {
       return true;
     }
 
@@ -128,7 +134,8 @@ function AddUserToGroup(props) {
     if (response.ok) {
       history.push(
         encodeURI(
-          `/groupadmin?groupId=${props.groupId}&groupName=${props.groupName
+          `/groupadmin?groupId=${props.groupId}&groupName=${
+            props.groupName
           }&addedUserEmail=${value}&flashMessageUntil=${Date.now() + 5000}`
         )
       );

--- a/ui/src/AddUserToGroup.js
+++ b/ui/src/AddUserToGroup.js
@@ -80,10 +80,12 @@ function AddUserToGroup(props) {
   }
 
   function isEmailAlreadyInGroup(newEmail) {
-    return location.state.existingEmailsInGroup.filter(
+    return (
+      location.state.existingEmailsInGroup.filter(
         (existingEmail) =>
-            existingEmail.toLowerCase() === newEmail.toLowerCase()
-    ).length > 0;
+          existingEmail.toLowerCase() === newEmail.toLowerCase()
+      ).length > 0
+    );
   }
 
   async function addUserToGroup() {

--- a/ui/src/AddUserToGroup.js
+++ b/ui/src/AddUserToGroup.js
@@ -68,17 +68,22 @@ function AddUserToGroup(props) {
   // Or by cutting and pasting a valid email address.
   // Check it's in out list and get the UserId
   function checkEmailExistsAndGetUserId(userInput) {
-    for (var i = 0; i < userList[0].users.length; i++) {
-      if (userList[0].users[i].email === userInput) {
-        return userList[0].users[i].id;
-      }
+    var matchingUser = userList[0].users.filter((user) => user.email.toLowerCase() === userInput.toLowerCase())
+
+    if (matchingUser.length === 0) {
+      return undefined;
     }
 
-    return undefined;
+    return matchingUser[0].id
   }
 
-  function isEmailAlreadyInGroup(userInput) {
-    return location.state.existingEmailsInGroup.includes(userInput);
+  function isEmailAlreadyInGroup(newEmail) {
+
+    if (location.state.existingEmailsInGroup.filter((existingEmail) => existingEmail.toLowerCase() === newEmail.toLowerCase()).length > 0) {
+      return true;
+    }
+
+    return false;
   }
 
   async function addUserToGroup() {
@@ -123,8 +128,7 @@ function AddUserToGroup(props) {
     if (response.ok) {
       history.push(
         encodeURI(
-          `/groupadmin?groupId=${props.groupId}&groupName=${
-            props.groupName
+          `/groupadmin?groupId=${props.groupId}&groupName=${props.groupName
           }&addedUserEmail=${value}&flashMessageUntil=${Date.now() + 5000}`
         )
       );


### PR DESCRIPTION
# Motivation and Context
Shouldn't be case sensitive adding emails

# What has changed
makes it case insensitive

# How to test?
Try to add a user to a group, manually change value in text box to change the case of some letters.  Check that the email it adds still correct (in this case it will use the capitalization/case already stored for the email

# Links
[<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->](https://trello.com/c/IQ5b0zYl/3309-defect-adding-user-emails-in-support-tool-is-case-sensitive-5)

# Screenshots (if appropriate):
