### PR TITLE
updated to eclipse-temurin:17-jdk-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM openjdk:17-slim
-CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-response-operations.jar"]
+FROM eclipse-temurin:17-jdk-alpine
 
-RUN groupadd --gid 999 response-operations && \
-    useradd --create-home --system --uid 999 --gid response-operations response-operations
+CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-response-operations.jar"]
 
-RUN apt-get update && \
-apt-get -yq install curl && \
-apt-get -yq clean && \
-rm -rf /var/lib/apt/lists/*
-
+RUN addgroup --gid 1000 response-operations && \
+    adduser --system --uid 1000 response-operations response-operations
 USER response-operations
 
 ARG JAR_FILE=ssdc-rm-response-operations*.jar
+
 COPY target/$JAR_FILE /opt/ssdc-rm-response-operations.jar


### PR DESCRIPTION
# Motivation and Context
OpenJDK support not great, use this eclipse alpine instead

# What has changed
Base image and healthchecks, user etc

# How to test?
Should all work with ATs etc with zero regression

# Links
https://trello.com/c/EK2yClBJ/40-migrate-java-base-docker-image-5