### PR TITLE
Update version of label checker and exclude patch updates from Depend…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
     labels:
       - "patch"
       - "dependencies"
@@ -11,6 +14,9 @@ updates:
     directory: "/ui"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
     labels:
       - "patch"
       - "dependencies"

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: docker://onsdigital/github-pr-label-checker:v1.2.7
+      - uses: docker://onsdigital/github-pr-label-checker:v1.6.13
         with:
           one_of: breaking change,feature,patch
           none_of: do not merge,work in progress


### PR DESCRIPTION
# Motivation and Context
- The label checker is way out of date and has features that are no longer supported
- Dependabot has been raising more PRs than we can deal with

# What has changed
- Updated the version of the label checker to the latest available (1.6.13)
- Excluded patch updates in the Dependabot config

# How to test?
- Label checker should work as normal
- We should in future see less Dependabot PRs being raised (this has already been tested for a while in caseprocessor)

# Links
https://trello.com/c/TDpQHGaw