### PR TITLE
Upgraded common-enitity-model version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.19.0</version>
+      <version>4.20.0</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>


### PR DESCRIPTION
Motivation and Context

It would be useful to be able to see how many cases each action rule has selected in the support tool UI

What has changed

Upped ssdc-rm-common-entity-model to latest version